### PR TITLE
Fix link error with GCC 10.2

### DIFF
--- a/emulator.h
+++ b/emulator.h
@@ -66,18 +66,18 @@ extern int p2out;
 extern int p3out;
 
 // current clock count
-unsigned int clocks;
+extern unsigned int clocks;
 
-int opt_exception_iret_sp;
-int opt_exception_iret_acc;
-int opt_exception_iret_psw;
-int opt_exception_acc_to_a;
-int opt_exception_stack;
-int opt_exception_invalid;
-int opt_clock_select;
-int opt_clock_hz;
-int opt_step_instruction;
-int opt_input_outputlow;
+extern int opt_exception_iret_sp;
+extern int opt_exception_iret_acc;
+extern int opt_exception_iret_psw;
+extern int opt_exception_acc_to_a;
+extern int opt_exception_stack;
+extern int opt_exception_invalid;
+extern int opt_clock_select;
+extern int opt_clock_hz;
+extern int opt_step_instruction;
+extern int opt_input_outputlow;
 
 
 


### PR DESCRIPTION
This change fix the 'multiple definition' link error when build with GCC 10.2
Add extern keyword for some variables in emulator.h

Error message I was getting:
```
gcc -g -Wall -Wextra core.o  disasm.o  emu.o  logicboard.o  mainview.o  memeditor.o  opcodes.o  options.o  popups.o -o emu -lcurses                                                                                                         
/usr/bin/ld: logicboard.o:/home/maximus/Projects/usb3_cap_re/tools/emu8051/emulator.h:69: multiple definition of `clocks'; emu.o:/home/maximus/Projects/usb3_cap_re/tools/emu8051/emulator.h:69: first defined here                         
/usr/bin/ld: logicboard.o:/home/maximus/Projects/usb3_cap_re/tools/emu8051/emulator.h:71: multiple definition of `opt_exception_iret_sp'; emu.o:/home/maximus/Projects/usb3_cap_re/tools/emu8051/emulator.h:71: first defined here
/usr/bin/ld: logicboard.o:/home/maximus/Projects/usb3_cap_re/tools/emu8051/emulator.h:72: multiple definition of `opt_exception_iret_acc'; emu.o:/home/maximus/Projects/usb3_cap_re/tools/emu8051/emulator.h:72: first defined here        
/usr/bin/ld: logicboard.o:/home/maximus/Projects/usb3_cap_re/tools/emu8051/emulator.h:73: multiple definition of `opt_exception_iret_psw'; emu.o:/home/maximus/Projects/usb3_cap_re/tools/emu8051/emulator.h:73: first defined here         
/usr/bin/ld: logicboard.o:/home/maximus/Projects/usb3_cap_re/tools/emu8051/emulator.h:74: multiple definition of `opt_exception_acc_to_a'; emu.o:/home/maximus/Projects/usb3_cap_re/tools/emu8051/emulator.h:74: first defined here
/usr/bin/ld: logicboard.o:/home/maximus/Projects/usb3_cap_re/tools/emu8051/emulator.h:75: multiple definition of `opt_exception_stack'; emu.o:/home/maximus/Projects/usb3_cap_re/tools/emu8051/emulator.h:75: first defined here           
/usr/bin/ld: logicboard.o:/home/maximus/Projects/usb3_cap_re/tools/emu8051/emulator.h:76: multiple definition of `opt_exception_invalid'; emu.o:/home/maximus/Projects/usb3_cap_re/tools/emu8051/emulator.h:76: first defined here
/usr/bin/ld: logicboard.o:/home/maximus/Projects/usb3_cap_re/tools/emu8051/emulator.h:77: multiple definition of `opt_clock_select'; emu.o:/home/maximus/Projects/usb3_cap_re/tools/emu8051/emulator.h:77: first defined here               
/usr/bin/ld: logicboard.o:/home/maximus/Projects/usb3_cap_re/tools/emu8051/emulator.h:78: multiple definition of `opt_clock_hz'; emu.o:/home/maximus/Projects/usb3_cap_re/tools/emu8051/emulator.h:78: first defined here                   
/usr/bin/ld: logicboard.o:/home/maximus/Projects/usb3_cap_re/tools/emu8051/emulator.h:79: multiple definition of `opt_step_instruction'; emu.o:/home/maximus/Projects/usb3_cap_re/tools/emu8051/emulator.h:79: first defined here          
/usr/bin/ld: logicboard.o:/home/maximus/Projects/usb3_cap_re/tools/emu8051/emulator.h:80: multiple definition of `opt_input_outputlow'; emu.o:/home/maximus/Projects/usb3_cap_re/tools/emu8051/emulator.h:80: first defined here
/usr/bin/ld: mainview.o:/home/maximus/Projects/usb3_cap_re/tools/emu8051/emulator.h:69: multiple definition of `clocks'; emu.o:/home/maximus/Projects/usb3_cap_re/tools/emu8051/emulator.h:69: first defined here                          
/usr/bin/ld: mainview.o:/home/maximus/Projects/usb3_cap_re/tools/emu8051/emulator.h:71: multiple definition of `opt_exception_iret_sp'; emu.o:/home/maximus/Projects/usb3_cap_re/tools/emu8051/emulator.h:71: first defined here            
/usr/bin/ld: mainview.o:/home/maximus/Projects/usb3_cap_re/tools/emu8051/emulator.h:72: multiple definition of `opt_exception_iret_acc'; emu.o:/home/maximus/Projects/usb3_cap_re/tools/emu8051/emulator.h:72: first defined here           /usr/bin/ld: mainview.o:/home/maximus/Projects/usb3_cap_re/tools/emu8051/emulator.h:73: multiple definition of `opt_exception_iret_psw'; emu.o:/home/maximus/Projects/usb3_cap_re/tools/emu8051/emulator.h:73: first defined here           
/usr/bin/ld: mainview.o:/home/maximus/Projects/usb3_cap_re/tools/emu8051/emulator.h:74: multiple definition of `opt_exception_acc_to_a'; emu.o:/home/maximus/Projects/usb3_cap_re/tools/emu8051/emulator.h:74: first defined here           
/usr/bin/ld: mainview.o:/home/maximus/Projects/usb3_cap_re/tools/emu8051/emulator.h:75: multiple definition of `opt_exception_stack'; emu.o:/home/maximus/Projects/usb3_cap_re/tools/emu8051/emulator.h:75: first defined here              
/usr/bin/ld: mainview.o:/home/maximus/Projects/usb3_cap_re/tools/emu8051/emulator.h:76: multiple definition of `opt_exception_invalid'; emu.o:/home/maximus/Projects/usb3_cap_re/tools/emu8051/emulator.h:76: first defined here            
/usr/bin/ld: mainview.o:/home/maximus/Projects/usb3_cap_re/tools/emu8051/emulator.h:77: multiple definition of `opt_clock_select'; emu.o:/home/maximus/Projects/usb3_cap_re/tools/emu8051/emulator.h:77: first defined here                 
/usr/bin/ld: mainview.o:/home/maximus/Projects/usb3_cap_re/tools/emu8051/emulator.h:78: multiple definition of `opt_clock_hz'; emu.o:/home/maximus/Projects/usb3_cap_re/tools/emu8051/emulator.h:78: first defined here                     
/usr/bin/ld: mainview.o:/home/maximus/Projects/usb3_cap_re/tools/emu8051/emulator.h:79: multiple definition of `opt_step_instruction'; emu.o:/home/maximus/Projects/usb3_cap_re/tools/emu8051/emulator.h:79: first defined here             
/usr/bin/ld: mainview.o:/home/maximus/Projects/usb3_cap_re/tools/emu8051/emulator.h:80: multiple definition of `opt_input_outputlow'; emu.o:/home/maximus/Projects/usb3_cap_re/tools/emu8051/emulator.h:80: first defined here     
.................repeated...   
```