### PR TITLE
Increase Performance of SFR callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,12 @@ On Debian/Ubuntu it is simply done as
 
     sudo apt-get install libncurses5 libncurses5-dev
 
+
+Code Style
+==========
+
+Arguments to functions are prefixed with "a", such as in
+
+    static int read_mem(struct em8051 *aCPU, int aAddress)
+
+Local variables are using standard [snake case](https://wikipedia.org/wiki/Snake_case).

--- a/emu.c
+++ b/emu.c
@@ -164,12 +164,9 @@ void setSpeed(int speed, int runmode)
 }
 
 
-void emu_sfrwrite(struct em8051 *aCPU, int aRegister)
+void emu_sfrwrite_SBUF(struct em8051 *aCPU, int aRegister)
 {
-    if (aRegister == REG_SBUF + 0x80)
-    {
-	    aCPU->serial_out_remaining_bits = 8;
-    }
+    aCPU->serial_out_remaining_bits = 8;
 }
 
 int emu_sfrread(struct em8051 *aCPU, int aRegister)
@@ -291,10 +288,18 @@ int main(int parc, char ** pars)
     emu.mUpperData   = malloc(128);
     emu.mSFR         = malloc(128);
     emu.except       = &emu_exception;
-    emu.sfrread      = &emu_sfrread;
-    emu.sfrwrite     = &emu_sfrwrite;
+    emu.sfrread      = malloc(128 * sizeof(em8051sfrread));
+    emu.sfrwrite     = malloc(128 * sizeof(em8051sfrwrite));
     emu.xread = NULL;
     emu.xwrite = NULL;
+
+    emu.sfrwrite[REG_SBUF] = emu_sfrwrite_SBUF;
+
+    emu.sfrread[REG_P0] = emu_sfrread;
+    emu.sfrread[REG_P1] = emu_sfrread;
+    emu.sfrread[REG_P2] = emu_sfrread;
+    emu.sfrread[REG_P3] = emu_sfrread;
+
     reset(&emu, 1);
 
     if (parc > 1)

--- a/emu.c
+++ b/emu.c
@@ -67,10 +67,7 @@ unsigned int clocks = 0;
 int view = MAIN_VIEW;
 
 // old port out values
-int p0out = 0;
-int p1out = 0;
-int p2out = 0;
-int p3out = 0;
+int pout[4] = { 0 };
 
 int breakpoint = -1;
 
@@ -183,38 +180,38 @@ int emu_sfrread(struct em8051 *aCPU, int aRegister)
     {
         if (aRegister == REG_P0 + 0x80)
         {
-            outputbyte = p0out;
+            outputbyte = pout[0];
         }
         if (aRegister == REG_P1 + 0x80)
         {
-            outputbyte =  p1out;
+            outputbyte = pout[1];
         }
         if (aRegister == REG_P2 + 0x80)
         {
-            outputbyte =  p2out;
+            outputbyte = pout[2];
         }
         if (aRegister == REG_P3 + 0x80)
         {
-            outputbyte =  p3out;
+            outputbyte = pout[3];
         }
     }
     else
     {
         if (aRegister == REG_P0 + 0x80)
         {
-            outputbyte = p0out = emu_readvalue(aCPU, "P0 port read", p0out, 2);
+            outputbyte = pout[0] = emu_readvalue(aCPU, "P0 port read", pout[0], 2);
         }
         if (aRegister == REG_P1 + 0x80)
         {
-            outputbyte = p1out = emu_readvalue(aCPU, "P1 port read", p1out, 2);
+            outputbyte = pout[1] = emu_readvalue(aCPU, "P1 port read", pout[1], 2);
         }
         if (aRegister == REG_P2 + 0x80)
         {
-            outputbyte = p2out = emu_readvalue(aCPU, "P2 port read", p2out, 2);
+            outputbyte = pout[2] = emu_readvalue(aCPU, "P2 port read", pout[2], 2);
         }
         if (aRegister == REG_P3 + 0x80)
         {
-            outputbyte = p3out = emu_readvalue(aCPU, "P3 port read", p3out, 2);
+            outputbyte = pout[3] = emu_readvalue(aCPU, "P3 port read", pout[3], 2);
         }
     }
     if (outputbyte != -1)

--- a/emu.c
+++ b/emu.c
@@ -284,12 +284,8 @@ int main(int parc, char ** pars)
     emu.mCodeMemSize = 65536;
     emu.mExtData     = malloc(65536);
     emu.mExtDataSize = 65536;
-    emu.mLowerData   = malloc(128);
     emu.mUpperData   = malloc(128);
-    emu.mSFR         = malloc(128);
     emu.except       = &emu_exception;
-    emu.sfrread      = malloc(128 * sizeof(em8051sfrread));
-    emu.sfrwrite     = malloc(128 * sizeof(em8051sfrwrite));
     emu.xread = NULL;
     emu.xwrite = NULL;
 

--- a/emu.c
+++ b/emu.c
@@ -280,11 +280,11 @@ int main(int parc, char ** pars)
     int ticked = 1;
 
     memset(&emu, 0, sizeof(emu));
-    emu.mCodeMem     = malloc(65536);
     emu.mCodeMemSize = 65536;
-    emu.mExtData     = malloc(65536);
+    emu.mCodeMem     = calloc(emu.mCodeMemSize, sizeof(unsigned char));
     emu.mExtDataSize = 65536;
-    emu.mUpperData   = malloc(128);
+    emu.mExtData     = calloc(emu.mExtDataSize, sizeof(unsigned char));
+    emu.mUpperData   = calloc(128, sizeof(unsigned char));
     emu.except       = &emu_exception;
     emu.xread = NULL;
     emu.xwrite = NULL;

--- a/emu8051.h
+++ b/emu8051.h
@@ -63,16 +63,16 @@ struct em8051
     int mCodeMemSize; 
     unsigned char *mExtData; // 0 - 64k, must be power of 2
     int mExtDataSize;
-    unsigned char *mLowerData; // 128 bytes
+    unsigned char mLowerData[128]; // 128 bytes
     unsigned char *mUpperData; // 0 or 128 bytes; leave to NULL if none
-    unsigned char *mSFR; // 128 bytes; (special function registers)
+    unsigned char mSFR[128]; // 128 bytes; (special function registers)
     int mPC; // Program Counter; outside memory area
     int mTickDelay; // How many ticks should we delay before continuing
     em8051operation op[256]; // function pointers to opcode handlers
     em8051decoder dec[256]; // opcode-to-string decoder handlers    
     em8051exception except; // callback: exceptional situation occurred
-    em8051sfrread *sfrread; // callback array: SFR register being read
-    em8051sfrwrite *sfrwrite; // callback array: SFR register written
+    em8051sfrread sfrread[128]; // callback array: SFR register being read
+    em8051sfrwrite sfrwrite[128]; // callback array: SFR register written
     em8051xread xread; // callback: external memory being read
     em8051xwrite xwrite; // callback: external memory being written
 

--- a/emu8051.h
+++ b/emu8051.h
@@ -71,8 +71,8 @@ struct em8051
     em8051operation op[256]; // function pointers to opcode handlers
     em8051decoder dec[256]; // opcode-to-string decoder handlers    
     em8051exception except; // callback: exceptional situation occurred
-    em8051sfrread sfrread; // callback: SFR register being read
-    em8051sfrwrite sfrwrite; // callback: SFR register written
+    em8051sfrread *sfrread; // callback array: SFR register being read
+    em8051sfrwrite *sfrwrite; // callback array: SFR register written
     em8051xread xread; // callback: external memory being read
     em8051xwrite xwrite; // callback: external memory being written
 

--- a/emulator.h
+++ b/emulator.h
@@ -60,10 +60,7 @@ extern int speed;
 extern int view;
 
 // old port out values
-extern int p0out;
-extern int p1out;
-extern int p2out;
-extern int p3out;
+extern int pout[];
 
 // current clock count
 extern unsigned int clocks;

--- a/logicboard.c
+++ b/logicboard.c
@@ -156,14 +156,14 @@ void logicboard_tick(struct em8051 *aCPU)
 
 			if (chardisplay4bmode == 0)
 			{
-				p1out = chardisplaydata;
+				pout[1] = chardisplaydata;
 			}
 			else
 			{	
 				if (chardisplaytick)
-					p1out = (chardisplaydata << 4) & 0xf0;
+					pout[1] = (chardisplaydata << 4) & 0xf0;
 				else
-					p1out = (chardisplaydata << 0) & 0xf0;
+					pout[1] = (chardisplaydata << 0) & 0xf0;
 				chardisplaytick = !chardisplaytick;
 			}
 		}
@@ -601,16 +601,16 @@ void logicboard_editor_keys(struct em8051 *aCPU, int ch)
         switch (position)
         {
         case 0:
-            p0out ^= 1 << xorvalue;
+            pout[0] ^= 1 << xorvalue;
             break;
         case 1:
-            p1out ^= 1 << xorvalue;
+            pout[1] ^= 1 << xorvalue;
             break;
         case 2:
-            p2out ^= 1 << xorvalue;
+            pout[2] ^= 1 << xorvalue;
             break;
         case 3:
-            p3out ^= 1 << xorvalue;
+            pout[3] ^= 1 << xorvalue;
             break;
         }
     }
@@ -635,7 +635,7 @@ void logicboard_update(struct em8051 *aCPU)
         ledstate[(data>>1)&1],
         ledstate[(data>>0)&1]);
 
-    data = p0out;
+    data = pout[0];
     mvprintw( 5, 2, "   %c %c %c %c %c %c %c %c",
         swstate[(data>>7)&1],
         swstate[(data>>6)&1],
@@ -657,7 +657,7 @@ void logicboard_update(struct em8051 *aCPU)
         ledstate[(data>>1)&1],
         ledstate[(data>>0)&1]);
 
-    data = p1out;
+    data = pout[1];
     mvprintw( 8, 2, "   %c %c %c %c %c %c %c %c",
         swstate[(data>>7)&1],
         swstate[(data>>6)&1],
@@ -679,7 +679,7 @@ void logicboard_update(struct em8051 *aCPU)
         ledstate[(data>>1)&1],
         ledstate[(data>>0)&1]);
 
-    data = p2out;
+    data = pout[2];
     mvprintw(11, 2, "   %c %c %c %c %c %c %c %c",
         swstate[(data>>7)&1],
         swstate[(data>>6)&1],
@@ -701,7 +701,7 @@ void logicboard_update(struct em8051 *aCPU)
         ledstate[(data>>1)&1],
         ledstate[(data>>0)&1]);
 
-    data = p3out;
+    data = pout[3];
     mvprintw(14, 2, "   %c %c %c %c %c %c %c %c",
         swstate[(data>>7)&1],
         swstate[(data>>6)&1],

--- a/opcodes.c
+++ b/opcodes.c
@@ -46,10 +46,11 @@ static int read_mem(struct em8051 *aCPU, int aAddress)
 {
     if (aAddress > 0x7f)
     {
-        if (aCPU->sfrread[aAddress - 0x80])
-            return aCPU->sfrread[aAddress - 0x80](aCPU, aAddress);
+        int reg_address = aAddress - 0x80;
+        if (aCPU->sfrread[reg_address])
+            return aCPU->sfrread[reg_address](aCPU, aAddress);
         else
-            return aCPU->mSFR[aAddress - 0x80];
+            return aCPU->mSFR[reg_address];
     }
     else
     {

--- a/opcodes.c
+++ b/opcodes.c
@@ -42,18 +42,18 @@
 #define RX_ADDRESS ((OPCODE & 7) + 8 * ((PSW & (PSWMASK_RS0|PSWMASK_RS1))>>PSW_RS0))
 #define CARRY ((PSW & PSWMASK_C) >> PSW_C)
 
-static int read_mem(struct em8051 *aCPU, int address)
+static int read_mem(struct em8051 *aCPU, int aAddress)
 {
-    if (address > 0x7f)
+    if (aAddress > 0x7f)
     {
-        if (aCPU->sfrread[address - 0x80])
-            return aCPU->sfrread[address - 0x80](aCPU, address);
+        if (aCPU->sfrread[aAddress - 0x80])
+            return aCPU->sfrread[aAddress - 0x80](aCPU, aAddress);
         else
-            return aCPU->mSFR[address - 0x80];
+            return aCPU->mSFR[aAddress - 0x80];
     }
     else
     {
-        return aCPU->mLowerData[address];
+        return aCPU->mLowerData[aAddress];
     }
 }
 

--- a/opcodes.c
+++ b/opcodes.c
@@ -46,11 +46,10 @@ static int read_mem(struct em8051 *aCPU, int aAddress)
 {
     if (aAddress > 0x7f)
     {
-        int reg_address = aAddress - 0x80;
-        if (aCPU->sfrread[reg_address])
-            return aCPU->sfrread[reg_address](aCPU, aAddress);
+        if (aCPU->sfrread[aAddress - 0x80])
+            return aCPU->sfrread[aAddress - 0x80](aCPU, aAddress);
         else
-            return aCPU->mSFR[reg_address];
+            return aCPU->mSFR[aAddress - 0x80];
     }
     else
     {

--- a/opcodes.c
+++ b/opcodes.c
@@ -42,18 +42,18 @@
 #define RX_ADDRESS ((OPCODE & 7) + 8 * ((PSW & (PSWMASK_RS0|PSWMASK_RS1))>>PSW_RS0))
 #define CARRY ((PSW & PSWMASK_C) >> PSW_C)
 
-static int read_mem(struct em8051 *aCPU, int aAddress)
+static int read_mem(struct em8051 *aCPU, int address)
 {
-    if (aAddress > 0x7f)
+    if (address > 0x7f)
     {
-        if (aCPU->sfrread)
-            return aCPU->sfrread(aCPU, aAddress);
+        if (aCPU->sfrread[address - 0x80])
+            return aCPU->sfrread[address - 0x80](aCPU, address);
         else
-            return aCPU->mSFR[aAddress - 0x80];
+            return aCPU->mSFR[address - 0x80];
     }
     else
     {
-        return aCPU->mLowerData[aAddress];
+        return aCPU->mLowerData[address];
     }
 }
 
@@ -174,8 +174,8 @@ static int inc_mem(struct em8051 *aCPU)
     if (address > 0x7f)
     {
         aCPU->mSFR[address - 0x80]++;
-        if (aCPU->sfrwrite)
-            aCPU->sfrwrite(aCPU, address);
+        if (aCPU->sfrwrite[address - 0x80])
+            aCPU->sfrwrite[address - 0x80](aCPU, address);
     }
     else
     {
@@ -220,8 +220,8 @@ static int jbc_bitaddr_offset(struct em8051 *aCPU)
         {
             aCPU->mSFR[address - 0x80] &= ~bitmask;
             PC += (signed char)OPERAND2 + 3;
-            if (aCPU->sfrwrite)
-                aCPU->sfrwrite(aCPU, address);
+            if (aCPU->sfrwrite[address - 0x80])
+                aCPU->sfrwrite[address - 0x80](aCPU, address);
         }
         else
         {
@@ -288,8 +288,8 @@ static int dec_mem(struct em8051 *aCPU)
     if (address > 0x7f)
     {
         aCPU->mSFR[address - 0x80]--;
-        if (aCPU->sfrwrite)
-            aCPU->sfrwrite(aCPU, address);
+        if (aCPU->sfrwrite[address - 0x80])
+            aCPU->sfrwrite[address - 0x80](aCPU, address);
     }
     else
     {
@@ -327,8 +327,8 @@ static int jb_bitaddr_offset(struct em8051 *aCPU)
         int bitmask = (1 << bit);
         int value;
         address &= 0xf8;        
-        if (aCPU->sfrread)
-            value = aCPU->sfrread(aCPU, address);
+        if (aCPU->sfrread[address - 0x80])
+            value = aCPU->sfrread[address - 0x80](aCPU, address);
         else
             value = aCPU->mSFR[address - 0x80];
         
@@ -423,8 +423,8 @@ static int jnb_bitaddr_offset(struct em8051 *aCPU)
         int bitmask = (1 << bit);
         int value;
         address &= 0xf8;        
-        if (aCPU->sfrread)
-            value = aCPU->sfrread(aCPU, address);
+        if (aCPU->sfrread[address - 0x80])
+            value = aCPU->sfrread[address - 0x80](aCPU, address);
         else
             value = aCPU->mSFR[address - 0x80];
         
@@ -557,8 +557,8 @@ static int orl_mem_a(struct em8051 *aCPU)
     if (address > 0x7f)
     {
         aCPU->mSFR[address - 0x80] |= ACC;
-        if (aCPU->sfrwrite)
-            aCPU->sfrwrite(aCPU, address);
+        if (aCPU->sfrwrite[address - 0x80])
+            aCPU->sfrwrite[address - 0x80](aCPU, address);
     }
     else
     {
@@ -574,8 +574,8 @@ static int orl_mem_imm(struct em8051 *aCPU)
     if (address > 0x7f)
     {
         aCPU->mSFR[address - 0x80] |= OPERAND2;
-        if (aCPU->sfrwrite)
-            aCPU->sfrwrite(aCPU, address);
+        if (aCPU->sfrwrite[address - 0x80])
+            aCPU->sfrwrite[address - 0x80](aCPU, address);
     }
     else
     {
@@ -643,8 +643,8 @@ static int anl_mem_a(struct em8051 *aCPU)
     if (address > 0x7f)
     {
         aCPU->mSFR[address - 0x80] &= ACC;
-        if (aCPU->sfrwrite)
-            aCPU->sfrwrite(aCPU, address);
+        if (aCPU->sfrwrite[address - 0x80])
+            aCPU->sfrwrite[address - 0x80](aCPU, address);
     }
     else
     {
@@ -660,8 +660,8 @@ static int anl_mem_imm(struct em8051 *aCPU)
     if (address > 0x7f)
     {
         aCPU->mSFR[address - 0x80] &= OPERAND2;
-        if (aCPU->sfrwrite)
-            aCPU->sfrwrite(aCPU, address);
+        if (aCPU->sfrwrite[address - 0x80])
+            aCPU->sfrwrite[address - 0x80](aCPU, address);
     }
     else
     {
@@ -727,8 +727,8 @@ static int xrl_mem_a(struct em8051 *aCPU)
     if (address > 0x7f)
     {
         aCPU->mSFR[address - 0x80] ^= ACC;
-        if (aCPU->sfrwrite)
-            aCPU->sfrwrite(aCPU, address);
+        if (aCPU->sfrwrite[address - 0x80])
+            aCPU->sfrwrite[address - 0x80](aCPU, address);
     }
     else
     {
@@ -744,8 +744,8 @@ static int xrl_mem_imm(struct em8051 *aCPU)
     if (address > 0x7f)
     {
         aCPU->mSFR[address - 0x80] ^= OPERAND2;
-        if (aCPU->sfrwrite)
-            aCPU->sfrwrite(aCPU, address);
+        if (aCPU->sfrwrite[address - 0x80])
+            aCPU->sfrwrite[address - 0x80](aCPU, address);
     }
     else
     {
@@ -815,8 +815,8 @@ static int orl_c_bitaddr(struct em8051 *aCPU)
         int bitmask = (1 << bit);
         int value;
         address &= 0xf8;        
-        if (aCPU->sfrread)
-            value = aCPU->sfrread(aCPU, address);
+        if (aCPU->sfrread[address - 0x80])
+            value = aCPU->sfrread[address - 0x80](aCPU, address);
         else
             value = aCPU->mSFR[address - 0x80];
 
@@ -857,8 +857,8 @@ static int mov_mem_imm(struct em8051 *aCPU)
     if (address > 0x7f)
     {
         aCPU->mSFR[address - 0x80] = OPERAND2;
-        if (aCPU->sfrwrite)
-            aCPU->sfrwrite(aCPU, address);
+        if (aCPU->sfrwrite[address - 0x80])
+            aCPU->sfrwrite[address - 0x80](aCPU, address);
     }
     else
     {
@@ -906,8 +906,8 @@ static int anl_c_bitaddr(struct em8051 *aCPU)
         int bitmask = (1 << bit);
         int value;
         address &= 0xf8;        
-        if (aCPU->sfrread)
-            value = aCPU->sfrread(aCPU, address);
+        if (aCPU->sfrread[address - 0x80])
+            value = aCPU->sfrread[address - 0x80](aCPU, address);
         else
             value = aCPU->mSFR[address - 0x80];
 
@@ -967,8 +967,8 @@ static int mov_mem_mem(struct em8051 *aCPU)
     if (address1 > 0x7f)
     {
         aCPU->mSFR[address1 - 0x80] = value;
-        if (aCPU->sfrwrite)
-            aCPU->sfrwrite(aCPU, address1);
+        if (aCPU->sfrwrite[address1 - 0x80])
+            aCPU->sfrwrite[address1 - 0x80](aCPU, address1);
     }
     else
     {
@@ -993,14 +993,14 @@ static int mov_mem_indir_rx(struct em8051 *aCPU)
                 value = aCPU->mUpperData[address2 - 0x80];
             }
             aCPU->mSFR[address1 - 0x80] = value;
-            if (aCPU->sfrwrite)
-                aCPU->sfrwrite(aCPU, address1);
+            if (aCPU->sfrwrite[address1 - 0x80])
+                aCPU->sfrwrite[address1 - 0x80](aCPU, address1);
         }
         else
         {
             aCPU->mSFR[address1 - 0x80] = aCPU->mLowerData[address2];
-            if (aCPU->sfrwrite)
-                aCPU->sfrwrite(aCPU, address1);
+            if (aCPU->sfrwrite[address1 - 0x80])
+                aCPU->sfrwrite[address1 - 0x80](aCPU, address1);
         }
     }
     else
@@ -1045,8 +1045,8 @@ static int mov_bitaddr_c(struct em8051 *aCPU)
         int bitmask = (1 << bit);
         address &= 0xf8;        
         aCPU->mSFR[address - 0x80] = (aCPU->mSFR[address - 0x80] & ~bitmask) | (carry << bit);
-        if (aCPU->sfrwrite)
-            aCPU->sfrwrite(aCPU, address);
+        if (aCPU->sfrwrite[address - 0x80])
+            aCPU->sfrwrite[address - 0x80](aCPU, address);
     }
     else
     {
@@ -1122,8 +1122,8 @@ static int orl_c_compl_bitaddr(struct em8051 *aCPU)
         int bitmask = (1 << bit);
         int value;
         address &= 0xf8;        
-        if (aCPU->sfrread)
-            value = aCPU->sfrread(aCPU, address);
+        if (aCPU->sfrread[address - 0x80])
+            value = aCPU->sfrread[address - 0x80](aCPU, address);
         else
             value = aCPU->mSFR[address - 0x80];
 
@@ -1154,8 +1154,8 @@ static int mov_c_bitaddr(struct em8051 *aCPU)
         int bitmask = (1 << bit);
         int value;
         address &= 0xf8;        
-        if (aCPU->sfrread)
-            value = aCPU->sfrread(aCPU, address);
+        if (aCPU->sfrread[address - 0x80])
+            value = aCPU->sfrread[address - 0x80](aCPU, address);
         else
             value = aCPU->mSFR[address - 0x80];
 
@@ -1231,8 +1231,8 @@ static int anl_c_compl_bitaddr(struct em8051 *aCPU)
         int bitmask = (1 << bit);
         int value;
         address &= 0xf8;        
-        if (aCPU->sfrread)
-            value = aCPU->sfrread(aCPU, address);
+        if (aCPU->sfrread[address - 0x80])
+            value = aCPU->sfrread[address - 0x80](aCPU, address);
         else
             value = aCPU->mSFR[address - 0x80];
 
@@ -1266,8 +1266,8 @@ static int cpl_bitaddr(struct em8051 *aCPU)
         int bitmask = (1 << bit);
         address &= 0xf8;        
         aCPU->mSFR[address - 0x80] ^= bitmask;
-        if (aCPU->sfrwrite)
-            aCPU->sfrwrite(aCPU, address);
+        if (aCPU->sfrwrite[address - 0x80])
+            aCPU->sfrwrite[address - 0x80](aCPU, address);
     }
     else
     {
@@ -1318,8 +1318,8 @@ static int cjne_a_mem_offset(struct em8051 *aCPU)
     int value;
     if (address > 0x7f)
     {
-        if (aCPU->sfrread)
-            value = aCPU->sfrread(aCPU, address);
+        if (aCPU->sfrread[address - 0x80])
+            value = aCPU->sfrread[address - 0x80](aCPU, address);
         else
             value = aCPU->mSFR[address - 0x80];
     }
@@ -1404,8 +1404,8 @@ static int clr_bitaddr(struct em8051 *aCPU)
         int bitmask = (1 << bit);
         address &= 0xf8;        
         aCPU->mSFR[address - 0x80] &= ~bitmask;
-        if (aCPU->sfrwrite)
-            aCPU->sfrwrite(aCPU, address);
+        if (aCPU->sfrwrite[address - 0x80])
+            aCPU->sfrwrite[address - 0x80](aCPU, address);
     }
     else
     {
@@ -1441,8 +1441,8 @@ static int xch_a_mem(struct em8051 *aCPU)
     {
         aCPU->mSFR[address - 0x80] = ACC;
         ACC = value;
-        if (aCPU->sfrwrite)
-            aCPU->sfrwrite(aCPU, address);
+        if (aCPU->sfrwrite[address - 0x80])
+            aCPU->sfrwrite[address - 0x80](aCPU, address);
     }
     else
     {
@@ -1483,8 +1483,8 @@ static int pop_mem(struct em8051 *aCPU)
     if (address > 0x7f)
     {
         aCPU->mSFR[address - 0x80] = pop_from_stack(aCPU);
-        if (aCPU->sfrwrite)
-            aCPU->sfrwrite(aCPU, address);
+        if (aCPU->sfrwrite[address - 0x80])
+            aCPU->sfrwrite[address - 0x80](aCPU, address);
     }
     else
     {
@@ -1506,8 +1506,8 @@ static int setb_bitaddr(struct em8051 *aCPU)
         int bitmask = (1 << bit);
         address &= 0xf8;        
         aCPU->mSFR[address - 0x80] |= bitmask;
-        if (aCPU->sfrwrite)
-            aCPU->sfrwrite(aCPU, address);
+        if (aCPU->sfrwrite[address - 0x80])
+            aCPU->sfrwrite[address - 0x80](aCPU, address);
     }
     else
     {
@@ -1567,8 +1567,8 @@ static int djnz_mem_offset(struct em8051 *aCPU)
     {
         aCPU->mSFR[address - 0x80]--;
         value = aCPU->mSFR[address - 0x80];
-        if (aCPU->sfrwrite)
-            aCPU->sfrwrite(aCPU, address);
+        if (aCPU->sfrwrite[address - 0x80])
+            aCPU->sfrwrite[address - 0x80](aCPU, address);
     }
     else
     {
@@ -1735,8 +1735,8 @@ static int mov_mem_a(struct em8051 *aCPU)
     if (address > 0x7f)
     {
         aCPU->mSFR[address - 0x80] = ACC;
-        if (aCPU->sfrwrite)
-            aCPU->sfrwrite(aCPU, address);
+        if (aCPU->sfrwrite[address - 0x80])
+            aCPU->sfrwrite[address - 0x80](aCPU, address);
     }
     else
     {
@@ -1847,8 +1847,8 @@ static int mov_mem_rx(struct em8051 *aCPU)
     if (address > 0x7f)
     {
         aCPU->mSFR[address - 0x80] = aCPU->mLowerData[rx];
-        if (aCPU->sfrwrite)
-            aCPU->sfrwrite(aCPU, address);
+        if (aCPU->sfrwrite[address - 0x80])
+            aCPU->sfrwrite[address - 0x80](aCPU, address);
     }
     else
     {


### PR DESCRIPTION
Some profiling showed that SFR callbacks are rather CPU costly. 

Now a RPI1B can run the emulator at realtime speed  via SSH 👍 

The ports where moved to an array, as it is easier to factorize. But it didnt change much the performance.

It is easier to write logicboard code so I let it in the PR.