### PR TITLE
Use fixed sized integers

### DIFF
--- a/core.c
+++ b/core.c
@@ -39,7 +39,7 @@ static void serial_tx(struct em8051 *aCPU) {
 	       return;
 
 	aCPU->serial_out_remaining_bits--;
-	uint8_t tx_bit = (aCPU->mSFR[REG_SBUF] >> aCPU->serial_out_remaining_bits) & 0x01;
+	bool tx_bit = (aCPU->mSFR[REG_SBUF] >> aCPU->serial_out_remaining_bits);
 	// Set P3.1 according to the currently clocked out SERIAL bit
 	aCPU->mSFR[REG_P3] &= ~(1 << 1);
 	if (tx_bit) aCPU->mSFR[REG_P3] |= (1 << 1);
@@ -446,10 +446,10 @@ void handle_interrupts(struct em8051 *aCPU)
     aCPU->int_sp[hi] = aCPU->mSFR[REG_SP];
 }
 
-uint8_t tick(struct em8051 *aCPU)
+bool tick(struct em8051 *aCPU)
 {
     uint8_t v;
-    uint8_t ticked = 0;
+    bool ticked = false;
 
     if (aCPU->mTickDelay)
     {
@@ -474,13 +474,13 @@ uint8_t tick(struct em8051 *aCPU)
     if (aCPU->mTickDelay == 0)
     {
         // IDL activate the idle mode to save power
-        uint8_t is_idle = (aCPU->mSFR[REG_PCON]) & 0x01;
+        bool is_idle = (aCPU->mSFR[REG_PCON]) & 0x01;
         if (is_idle) {
             aCPU->mTickDelay = 1;
         } else {
             aCPU->mTickDelay = aCPU->op[aCPU->mCodeMem[aCPU->mPC & (aCPU->mCodeMemMaxIdx)]](aCPU);
         }
-        ticked = 1;
+        ticked = true;
         // update parity bit
         v = aCPU->mSFR[REG_ACC];
         v ^= v >> 4;
@@ -496,12 +496,12 @@ uint8_t tick(struct em8051 *aCPU)
 
 uint8_t decode(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
 {
-    uint8_t is_idle = (aCPU->mSFR[REG_PCON]) & 0x01;
+    bool is_idle = (aCPU->mSFR[REG_PCON]) & 0x01;
     if (is_idle) {
         sprintf(aBuffer, "IDLE");
         return 0;
     }
-    uint8_t is_powerdown = (aCPU->mSFR[REG_PCON]) & 0x02;
+    bool is_powerdown = (aCPU->mSFR[REG_PCON]) & 0x02;
     if (is_powerdown) {
         sprintf(aBuffer, "POWER DOWN");
         return 0;
@@ -512,7 +512,7 @@ uint8_t decode(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
 void disasm_setptrs(struct em8051 *aCPU);
 void op_setptrs(struct em8051 *aCPU);
 
-void reset(struct em8051 *aCPU, uint8_t aWipe)
+void reset(struct em8051 *aCPU, bool aWipe)
 {
     // clear memory, set registers to bootup values, etc    
     if (aWipe)

--- a/core.c
+++ b/core.c
@@ -39,7 +39,7 @@ static void serial_tx(struct em8051 *aCPU) {
 	       return;
 
 	aCPU->serial_out_remaining_bits--;
-	int tx_bit = (aCPU->mSFR[REG_SBUF] >> aCPU->serial_out_remaining_bits) & 0x01;
+	uint8_t tx_bit = (aCPU->mSFR[REG_SBUF] >> aCPU->serial_out_remaining_bits) & 0x01;
 	// Set P3.1 according to the currently clocked out SERIAL bit
 	aCPU->mSFR[REG_P3] &= ~(1 << 1);
 	if (tx_bit) aCPU->mSFR[REG_P3] |= (1 << 1);
@@ -56,8 +56,8 @@ static void serial_tx(struct em8051 *aCPU) {
 
 static void timer_tick(struct em8051 *aCPU)
 {
-    int increment;
-    int v;
+    uint8_t increment;
+    uint16_t v;
 
     // TODO: External int 0 flag
 
@@ -309,9 +309,9 @@ static void timer_tick(struct em8051 *aCPU)
 
 void handle_interrupts(struct em8051 *aCPU)
 {
-    int dest_ip = -1;
-    int hi = 0;
-    int lo = 0;
+    int16_t dest_ip = -1;
+    uint8_t hi = 0;
+    uint8_t lo = 0;
 
     // can't interrupt high level
     if (aCPU->mInterruptActive > 1) 
@@ -446,10 +446,10 @@ void handle_interrupts(struct em8051 *aCPU)
     aCPU->int_sp[hi] = aCPU->mSFR[REG_SP];
 }
 
-int tick(struct em8051 *aCPU)
+uint8_t tick(struct em8051 *aCPU)
 {
-    int v;
-    int ticked = 0;
+    uint8_t v;
+    uint8_t ticked = 0;
 
     if (aCPU->mTickDelay)
     {
@@ -474,11 +474,11 @@ int tick(struct em8051 *aCPU)
     if (aCPU->mTickDelay == 0)
     {
         // IDL activate the idle mode to save power
-        int is_idle = (aCPU->mSFR[REG_PCON]) & 0x01;
+        uint8_t is_idle = (aCPU->mSFR[REG_PCON]) & 0x01;
         if (is_idle) {
             aCPU->mTickDelay = 1;
         } else {
-            aCPU->mTickDelay = aCPU->op[aCPU->mCodeMem[aCPU->mPC & (aCPU->mCodeMemSize - 1)]](aCPU);
+            aCPU->mTickDelay = aCPU->op[aCPU->mCodeMem[aCPU->mPC & (aCPU->mCodeMemMaxIdx)]](aCPU);
         }
         ticked = 1;
         // update parity bit
@@ -494,31 +494,31 @@ int tick(struct em8051 *aCPU)
     return ticked;
 }
 
-int decode(struct em8051 *aCPU, int aPosition, char *aBuffer)
+uint8_t decode(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
 {
-    int is_idle = (aCPU->mSFR[REG_PCON]) & 0x01;
+    uint8_t is_idle = (aCPU->mSFR[REG_PCON]) & 0x01;
     if (is_idle) {
         sprintf(aBuffer, "IDLE");
         return 0;
     }
-    int is_powerdown = (aCPU->mSFR[REG_PCON]) & 0x02;
+    uint8_t is_powerdown = (aCPU->mSFR[REG_PCON]) & 0x02;
     if (is_powerdown) {
         sprintf(aBuffer, "POWER DOWN");
         return 0;
     }
-    return aCPU->dec[aCPU->mCodeMem[aPosition & (aCPU->mCodeMemSize - 1)]](aCPU, aPosition, aBuffer);
+    return aCPU->dec[aCPU->mCodeMem[aPosition & (aCPU->mCodeMemMaxIdx)]](aCPU, aPosition, aBuffer);
 }
 
 void disasm_setptrs(struct em8051 *aCPU);
 void op_setptrs(struct em8051 *aCPU);
 
-void reset(struct em8051 *aCPU, int aWipe)
+void reset(struct em8051 *aCPU, uint8_t aWipe)
 {
     // clear memory, set registers to bootup values, etc    
     if (aWipe)
     {
-        memset(aCPU->mCodeMem, 0, aCPU->mCodeMemSize);
-        memset(aCPU->mExtData, 0, aCPU->mExtDataSize);
+        memset(aCPU->mCodeMem, 0, aCPU->mCodeMemMaxIdx+1);
+        memset(aCPU->mExtData, 0, aCPU->mExtDataMaxIdx+1);
         memset(aCPU->mLowerData, 0, 128);
         if (aCPU->mUpperData) 
             memset(aCPU->mUpperData, 0, 128);

--- a/emu.c
+++ b/emu.c
@@ -164,12 +164,12 @@ void setSpeed(int speed, int runmode)
 }
 
 
-void emu_sfrwrite_SBUF(struct em8051 *aCPU, int aRegister)
+void emu_sfrwrite_SBUF(struct em8051 *aCPU, uint8_t aRegister)
 {
     aCPU->serial_out_remaining_bits = 8;
 }
 
-int emu_sfrread(struct em8051 *aCPU, int aRegister)
+uint8_t emu_sfrread(struct em8051 *aCPU, uint8_t aRegister)
 {
     int outputbyte = -1;
 
@@ -280,10 +280,10 @@ int main(int parc, char ** pars)
     int ticked = 1;
 
     memset(&emu, 0, sizeof(emu));
-    emu.mCodeMemSize = 65536;
-    emu.mCodeMem     = calloc(emu.mCodeMemSize, sizeof(unsigned char));
-    emu.mExtDataSize = 65536;
-    emu.mExtData     = calloc(emu.mExtDataSize, sizeof(unsigned char));
+    emu.mCodeMemMaxIdx = 65536-1;
+    emu.mCodeMem     = calloc(emu.mCodeMemMaxIdx+1, sizeof(unsigned char));
+    emu.mExtDataMaxIdx = 65536-1;
+    emu.mExtData     = calloc(emu.mExtDataMaxIdx+1, sizeof(unsigned char));
     emu.mUpperData   = calloc(128, sizeof(unsigned char));
     emu.except       = &emu_exception;
     emu.xread = NULL;

--- a/emu8051.h
+++ b/emu8051.h
@@ -27,6 +27,7 @@
  */
 
 #include <stdint.h>
+#include <stdbool.h>
 
 struct em8051;
 
@@ -98,7 +99,7 @@ struct em8051
 void reset(struct em8051 *aCPU, uint8_t aWipe);
 
 // run one emulator tick, or 12 hardware clock cycles.
-// returns 1 if a new operation was executed.
+// returns "true" if a new operation was executed.
 uint8_t tick(struct em8051 *aCPU);
 
 // decode the next operation as character string.

--- a/emu8051.h
+++ b/emu8051.h
@@ -26,48 +26,50 @@
  * Emulator core header file
  */
 
+#include <stdint.h>
+
 struct em8051;
 
 // Operation: returns number of ticks the operation should take
-typedef int (*em8051operation)(struct em8051 *aCPU); 
+typedef uint8_t (*em8051operation)(struct em8051 *aCPU);
 
 // Decodes opcode at position, and fills the buffer with the assembler code. 
 // Returns how many bytes the opcode takes.
-typedef int (*em8051decoder)(struct em8051 *aCPU, int aPosition, char *aBuffer);
+typedef uint8_t (*em8051decoder)(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer);
 
 // Callback: some exceptional situation occurred. See EM8051_EXCEPTION enum, below
 typedef void (*em8051exception)(struct em8051 *aCPU, int aCode);
 
 // Callback: an SFR register is about to be read (not called for 'a' ops nor psw changes)
 // Default is to return the value in the SFR register. Ports may act differently.
-typedef int (*em8051sfrread)(struct em8051 *aCPU, int aRegister);
+typedef uint8_t (*em8051sfrread)(struct em8051 *aCPU, uint8_t aRegister);
 
 // Callback: an SFR register has changed (not called for 'a' ops)
 // Default is to do nothing
-typedef void (*em8051sfrwrite)(struct em8051 *aCPU, int aRegister);
+typedef void (*em8051sfrwrite)(struct em8051 *aCPU, uint8_t aRegister);
 
 // Callback: writing to external memory
 // Default is to update external memory
 // (can be used to control some peripherals)
-typedef void (*em8051xwrite)(struct em8051 *aCPU, int aAddress, int aValue);
+typedef void (*em8051xwrite)(struct em8051 *aCPU, uint16_t aAddress, uint8_t aValue);
 
 // Callback: reading from external memory
 // Default is to return the value in external memory 
 // (can be used to control some peripherals)
-typedef int (*em8051xread)(struct em8051 *aCPU, int aAddress);
+typedef uint8_t (*em8051xread)(struct em8051 *aCPU, uint16_t aAddress);
 
 
 struct em8051
 {
     unsigned char *mCodeMem; // 1k - 64k, must be power of 2
-    int mCodeMemSize; 
+    uint16_t mCodeMemMaxIdx;
     unsigned char *mExtData; // 0 - 64k, must be power of 2
-    int mExtDataSize;
+    uint16_t mExtDataMaxIdx;
     unsigned char mLowerData[128]; // 128 bytes
     unsigned char *mUpperData; // 0 or 128 bytes; leave to NULL if none
     unsigned char mSFR[128]; // 128 bytes; (special function registers)
-    int mPC; // Program Counter; outside memory area
-    int mTickDelay; // How many ticks should we delay before continuing
+    uint16_t mPC; // Program Counter; outside memory area
+    uint8_t mTickDelay; // How many ticks should we delay before continuing
     em8051operation op[256]; // function pointers to opcode handlers
     em8051decoder dec[256]; // opcode-to-string decoder handlers    
     em8051exception except; // callback: exceptional situation occurred
@@ -77,41 +79,41 @@ struct em8051
     em8051xwrite xwrite; // callback: external memory being written
 
     // Internal values for interrupt services etc.
-    int mInterruptActive;
+    uint8_t mInterruptActive;
     // Stored register values for interrupts (exception checking)
-    int int_a[2];
-    int int_psw[2];
-    int int_sp[2];
+    uint8_t int_a[2];
+    uint8_t int_psw[2];
+    uint8_t int_sp[2];
 
     // Internal handling of UART
     char serial_out[18]; // The shown size is only 18 chars
-    int serial_out_idx;
-    int serial_out_remaining_bits;
-    int serial_interrupt_trigger;
+    uint8_t serial_out_idx;
+    uint8_t serial_out_remaining_bits;
+    uint8_t serial_interrupt_trigger;
 };
 
 // set the emulator into reset state. Must be called before tick(), as
 // it also initializes the function pointers. aWipe tells whether to reset
 // all memory to zero.
-void reset(struct em8051 *aCPU, int aWipe);
+void reset(struct em8051 *aCPU, uint8_t aWipe);
 
 // run one emulator tick, or 12 hardware clock cycles.
 // returns 1 if a new operation was executed.
-int tick(struct em8051 *aCPU);
+uint8_t tick(struct em8051 *aCPU);
 
 // decode the next operation as character string.
 // buffer must be big enough (64 bytes is very safe). 
 // Returns length of opcode.
-int decode(struct em8051 *aCPU, int aPosition, char *aBuffer);
+uint8_t decode(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer);
 
 // Load an intel hex format object file. Returns negative for errors.
 int load_obj(struct em8051 *aCPU, char *aFilename);
 
 // Alternate way to execute an opcode (switch-structure instead of function pointers)
-int do_op(struct em8051 *aCPU);
+uint8_t do_op(struct em8051 *aCPU);
 
 // Internal: Pushes a value into stack
-void push_to_stack(struct em8051 *aCPU, int aValue);
+void push_to_stack(struct em8051 *aCPU, uint8_t aValue);
 
 
 // SFR register locations

--- a/emu8051.h
+++ b/emu8051.h
@@ -90,17 +90,17 @@ struct em8051
     char serial_out[18]; // The shown size is only 18 chars
     uint8_t serial_out_idx;
     uint8_t serial_out_remaining_bits;
-    uint8_t serial_interrupt_trigger;
+    bool serial_interrupt_trigger;
 };
 
 // set the emulator into reset state. Must be called before tick(), as
 // it also initializes the function pointers. aWipe tells whether to reset
 // all memory to zero.
-void reset(struct em8051 *aCPU, uint8_t aWipe);
+void reset(struct em8051 *aCPU, bool aWipe);
 
 // run one emulator tick, or 12 hardware clock cycles.
 // returns "true" if a new operation was executed.
-uint8_t tick(struct em8051 *aCPU);
+bool tick(struct em8051 *aCPU);
 
 // decode the next operation as character string.
 // buffer must be big enough (64 bytes is very safe). 

--- a/emulator.h
+++ b/emulator.h
@@ -81,7 +81,7 @@ extern int opt_input_outputlow;
 // emu.c
 extern int getTick();
 extern void setSpeed(int speed, int runmode);
-extern int emu_sfrread(struct em8051 *aCPU, int aRegister);
+//extern uint8_t emu_sfrread(struct em8051 *aCPU, uint8_t aRegister);
 extern void refreshview(struct em8051 *aCPU);
 extern void change_view(struct em8051 *aCPU, int changeto);
 

--- a/mainview.c
+++ b/mainview.c
@@ -295,7 +295,7 @@ void mainview_editor_keys(struct em8051 *aCPU, int ch)
         memmode++;
         if (memmode == 1 && aCPU->mUpperData == NULL) 
             memmode++;
-        if (memmode == 3 && aCPU->mExtDataSize == 0)
+        if (memmode == 3 && aCPU->mExtData == NULL)
             memmode++;
         if (memmode == 5)
             memmode = 0;
@@ -395,10 +395,10 @@ void mainview_editor_keys(struct em8051 *aCPU, int ch)
         maxmem = 128;
         break;
     case 3:
-        maxmem = aCPU->mExtDataSize;
+        maxmem = aCPU->mExtDataMaxIdx+1;
         break;
     case 4:
-        maxmem = aCPU->mCodeMemSize;
+        maxmem = aCPU->mCodeMemMaxIdx+1;
         break;
     }
 
@@ -528,7 +528,7 @@ void mainview_update(struct em8051 *aCPU)
             stringpos += sprintf(temp + stringpos,"\n%04X  ", old_pc & 0xffff);
             
             for (i = 0; i < opcode_bytes; i++)
-                stringpos += sprintf(temp + stringpos,"%02X ", aCPU->mCodeMem[(old_pc + i) & (aCPU->mCodeMemSize - 1)]);
+                stringpos += sprintf(temp + stringpos,"%02X ", aCPU->mCodeMem[(old_pc + i) & (aCPU->mCodeMemMaxIdx)]);
             
             for (i = opcode_bytes; i < 3; i++)
                 stringpos += sprintf(temp + stringpos,"   ");

--- a/memeditor.c
+++ b/memeditor.c
@@ -96,7 +96,7 @@ void build_memeditor_view(struct em8051 *aCPU)
     box(eds[3].box,ACS_VLINE,ACS_HLINE);
     mvwaddstr(eds[3].box, 0, 2, "External");
     eds[3].view = subwin(eds[3].box, eds[3].lines - 2, 38, 1, 41);    
-    eds[3].maxmem = aCPU->mExtDataSize;
+    eds[3].maxmem = aCPU->mExtDataMaxIdx+1;
     eds[3].memarea = aCPU->mExtData;
     eds[3].memviewoffset = 0;
 
@@ -105,7 +105,7 @@ void build_memeditor_view(struct em8051 *aCPU)
     box(eds[4].box,ACS_VLINE,ACS_HLINE);
     mvwaddstr(eds[4].box, 0, 2, "ROM");
     eds[4].view = subwin(eds[4].box, eds[4].lines - 2, 38, eds[3].lines + 1, 41);
-    eds[4].maxmem = aCPU->mCodeMemSize;
+    eds[4].maxmem = aCPU->mCodeMemMaxIdx+1;
     eds[4].memarea = aCPU->mCodeMem;     
     eds[4].memviewoffset = 0;
 
@@ -137,7 +137,7 @@ void memeditor_editor_keys(struct em8051 *aCPU, int ch)
         focus++;
         if (focus == 1 && aCPU->mUpperData == NULL) 
             focus++;
-        if (focus == 3 && aCPU->mExtDataSize == 0)
+        if (focus == 3 && aCPU->mExtData == NULL)
             focus++;
         if (focus == 5)
             focus = 0;

--- a/opcodes.c
+++ b/opcodes.c
@@ -208,8 +208,9 @@ static uint8_t inc_indir_rx(struct em8051 *aCPU)
 
 static uint8_t jbc_bitaddr_offset(struct em8051 *aCPU)
 {
-    // "Note: when this instruction is used to test an output pin, the value used 
-    // as the original data will be read from the output data latch, not the input pin"
+    // Note: when this instruction is used to test an output pin, the value used
+    // as the original data will be read from the output data latch, not the input pin
+    // -- MCS(r) 51 Microcontroller Family User's Manual
     uint8_t address = OPERAND1;
     if (address > 0x7f)
     {
@@ -1042,8 +1043,9 @@ static uint8_t mov_bitaddr_c(struct em8051 *aCPU)
     bool carry = CARRY;
     if (address > 0x7f)
     {
-        // Data sheet does not explicitly say that the modification source
-        // is read from output latch, but we'll assume that is what happens.
+        // Note: when this instruction is used to test an output pin, the value used
+        // as the original data will be read from the output data latch, not the input pin
+        // -- MCS(r) 51 Microcontroller Family User's Manual
         uint8_t bitaddr = address & 7;
         uint8_t bitmask = (1 << bitaddr);
         address &= 0xf8;        
@@ -1263,8 +1265,9 @@ static uint8_t cpl_bitaddr(struct em8051 *aCPU)
     uint8_t address = OPERAND1;
     if (address > 0x7f)
     {
-        // Data sheet does not explicitly say that the modification source
-        // is read from output latch, but we'll assume that is what happens.
+        // Note: when this instruction is used to test an output pin, the value used
+        // as the original data will be read from the output data latch, not the input pin
+        // -- MCS(r) 51 Microcontroller Family User's Manual
         uint8_t bitaddr = address & 7;
         uint8_t bitmask = (1 << bitaddr);
         address &= 0xf8;        
@@ -1401,8 +1404,9 @@ static uint8_t clr_bitaddr(struct em8051 *aCPU)
     uint8_t address = OPERAND1;
     if (address > 0x7f)
     {
-        // Data sheet does not explicitly say that the modification source
-        // is read from output latch, but we'll assume that is what happens.
+        // Note: when this instruction is used to test an output pin, the value used
+        // as the original data will be read from the output data latch, not the input pin
+        // -- MCS(r) 51 Microcontroller Family User's Manual
         uint8_t bitaddr = address & 7;
         uint8_t bitmask = (1 << bitaddr);
         address &= 0xf8;        
@@ -1503,8 +1507,9 @@ static uint8_t setb_bitaddr(struct em8051 *aCPU)
     uint8_t address = OPERAND1;
     if (address > 0x7f)
     {
-        // Data sheet does not explicitly say that the modification source
-        // is read from output latch, but we'll assume that is what happens.
+        // Note: when this instruction is used to test an output pin, the value used
+        // as the original data will be read from the output data latch, not the input pin
+        // -- MCS(r) 51 Microcontroller Family User's Manual
         uint8_t bitaddr = address & 7;
         uint8_t bitmask = (1 << bitaddr);
         address &= 0xf8;        

--- a/opcodes.c
+++ b/opcodes.c
@@ -213,8 +213,8 @@ static uint8_t jbc_bitaddr_offset(struct em8051 *aCPU)
     uint8_t address = OPERAND1;
     if (address > 0x7f)
     {
-        bool bit = address & 7;
-        uint8_t bitmask = (1 << bit);
+        uint8_t bitaddr = address & 7;
+        uint8_t bitmask = (1 << bitaddr);
         uint8_t value;
         address &= 0xf8;        
         value = aCPU->mSFR[address - 0x80];
@@ -233,8 +233,8 @@ static uint8_t jbc_bitaddr_offset(struct em8051 *aCPU)
     }
     else
     {
-        bool bit = address & 7;
-        uint8_t bitmask = (1 << bit);
+        uint8_t bitaddr = address & 7;
+        uint8_t bitmask = (1 << bitaddr);
         address >>= 3;
         address += 0x20;
         if (aCPU->mLowerData[address] & bitmask)
@@ -326,8 +326,8 @@ static uint8_t jb_bitaddr_offset(struct em8051 *aCPU)
     uint8_t address = OPERAND1;
     if (address > 0x7f)
     {
-        bool bit = address & 7;
-        uint8_t bitmask = (1 << bit);
+        uint8_t bitaddr = address & 7;
+        uint8_t bitmask = (1 << bitaddr);
         uint8_t value;
         address &= 0xf8;        
         if (aCPU->sfrread[address - 0x80])
@@ -346,8 +346,8 @@ static uint8_t jb_bitaddr_offset(struct em8051 *aCPU)
     }
     else
     {
-        bool bit = address & 7;
-        uint8_t bitmask = (1 << bit);
+        uint8_t bitaddr = address & 7;
+        uint8_t bitmask = (1 << bitaddr);
         address >>= 3;
         address += 0x20;
         if (aCPU->mLowerData[address] & bitmask)
@@ -422,8 +422,8 @@ static uint8_t jnb_bitaddr_offset(struct em8051 *aCPU)
     uint8_t address = OPERAND1;
     if (address > 0x7f)
     {
-        bool bit = address & 7;
-        uint8_t bitmask = (1 << bit);
+        uint8_t bitaddr = address & 7;
+        uint8_t bitmask = (1 << bitaddr);
         uint8_t value;
         address &= 0xf8;        
         if (aCPU->sfrread[address - 0x80])
@@ -442,8 +442,8 @@ static uint8_t jnb_bitaddr_offset(struct em8051 *aCPU)
     }
     else
     {
-        bool bit = address & 7;
-        uint8_t bitmask = (1 << bit);
+        uint8_t bitaddr = address & 7;
+        uint8_t bitmask = (1 << bitaddr);
         address >>= 3;
         address += 0x20;
         if (!(aCPU->mLowerData[address] & bitmask))
@@ -814,8 +814,8 @@ static uint8_t orl_c_bitaddr(struct em8051 *aCPU)
     bool carry = CARRY;
     if (address > 0x7f)
     {
-        bool bit = address & 7;
-        uint8_t bitmask = (1 << bit);
+        uint8_t bitaddr = address & 7;
+        uint8_t bitmask = (1 << bitaddr);
         uint8_t value;
         address &= 0xf8;        
         if (aCPU->sfrread[address - 0x80])
@@ -829,8 +829,8 @@ static uint8_t orl_c_bitaddr(struct em8051 *aCPU)
     }
     else
     {
-        bool bit = address & 7;
-        uint8_t bitmask = (1 << bit);
+        uint8_t bitaddr = address & 7;
+        uint8_t bitmask = (1 << bitaddr);
         uint8_t value;
         address >>= 3;
         address += 0x20;
@@ -905,8 +905,8 @@ static uint8_t anl_c_bitaddr(struct em8051 *aCPU)
     bool carry = CARRY;
     if (address > 0x7f)
     {
-        bool bit = address & 7;
-        uint8_t bitmask = (1 << bit);
+        uint8_t bitaddr = address & 7;
+        uint8_t bitmask = (1 << bitaddr);
         uint8_t value;
         address &= 0xf8;        
         if (aCPU->sfrread[address - 0x80])
@@ -920,8 +920,8 @@ static uint8_t anl_c_bitaddr(struct em8051 *aCPU)
     }
     else
     {
-        bool bit = address & 7;
-        uint8_t bitmask = (1 << bit);
+        uint8_t bitaddr = address & 7;
+        uint8_t bitmask = (1 << bitaddr);
         uint8_t value;
         address >>= 3;
         address += 0x20;
@@ -1044,20 +1044,20 @@ static uint8_t mov_bitaddr_c(struct em8051 *aCPU)
     {
         // Data sheet does not explicitly say that the modification source
         // is read from output latch, but we'll assume that is what happens.
-        bool bit = address & 7;
-        uint8_t bitmask = (1 << bit);
+        uint8_t bitaddr = address & 7;
+        uint8_t bitmask = (1 << bitaddr);
         address &= 0xf8;        
-        aCPU->mSFR[address - 0x80] = (aCPU->mSFR[address - 0x80] & ~bitmask) | (carry << bit);
+        aCPU->mSFR[address - 0x80] = (aCPU->mSFR[address - 0x80] & ~bitmask) | (carry << bitaddr);
         if (aCPU->sfrwrite[address - 0x80])
             aCPU->sfrwrite[address - 0x80](aCPU, address);
     }
     else
     {
-        bool bit = address & 7;
-        uint8_t bitmask = (1 << bit);
+        uint8_t bitaddr = address & 7;
+        uint8_t bitmask = (1 << bitaddr);
         address >>= 3;
         address += 0x20;
-        aCPU->mLowerData[address] = (aCPU->mLowerData[address] & ~bitmask) | (carry << bit);
+        aCPU->mLowerData[address] = (aCPU->mLowerData[address] & ~bitmask) | (carry << bitaddr);
     }
     PC += 2;
     return 1;
@@ -1121,8 +1121,8 @@ static uint8_t orl_c_compl_bitaddr(struct em8051 *aCPU)
     bool carry = CARRY;
     if (address > 0x7f)
     {
-        bool bit = address & 7;
-        uint8_t bitmask = (1 << bit);
+        uint8_t bitaddr = address & 7;
+        uint8_t bitmask = (1 << bitaddr);
         uint8_t value;
         address &= 0xf8;        
         if (aCPU->sfrread[address - 0x80])
@@ -1136,8 +1136,8 @@ static uint8_t orl_c_compl_bitaddr(struct em8051 *aCPU)
     }
     else
     {
-        bool bit = address & 7;
-        uint8_t bitmask = (1 << bit);
+        uint8_t bitaddr = address & 7;
+        uint8_t bitmask = (1 << bitaddr);
         uint8_t value;
         address >>= 3;
         address += 0x20;
@@ -1153,8 +1153,8 @@ static uint8_t mov_c_bitaddr(struct em8051 *aCPU)
     uint8_t address = OPERAND1;
     if (address > 0x7f)
     {
-        bool bit = address & 7;
-        uint8_t bitmask = (1 << bit);
+        uint8_t bitaddr = address & 7;
+        uint8_t bitmask = (1 << bitaddr);
         uint8_t value;
         address &= 0xf8;        
         if (aCPU->sfrread[address - 0x80])
@@ -1168,8 +1168,8 @@ static uint8_t mov_c_bitaddr(struct em8051 *aCPU)
     }
     else
     {
-        bool bit = address & 7;
-        uint8_t bitmask = (1 << bit);
+        uint8_t bitaddr = address & 7;
+        uint8_t bitmask = (1 << bitaddr);
         uint8_t value;
         address >>= 3;
         address += 0x20;
@@ -1230,8 +1230,8 @@ static uint8_t anl_c_compl_bitaddr(struct em8051 *aCPU)
     bool carry = CARRY;
     if (address > 0x7f)
     {
-        bool bit = address & 7;
-        uint8_t bitmask = (1 << bit);
+        uint8_t bitaddr = address & 7;
+        uint8_t bitmask = (1 << bitaddr);
         uint8_t value;
         address &= 0xf8;        
         if (aCPU->sfrread[address - 0x80])
@@ -1245,8 +1245,8 @@ static uint8_t anl_c_compl_bitaddr(struct em8051 *aCPU)
     }
     else
     {
-        bool bit = address & 7;
-        uint8_t bitmask = (1 << bit);
+        uint8_t bitaddr = address & 7;
+        uint8_t bitmask = (1 << bitaddr);
         uint8_t value;
         address >>= 3;
         address += 0x20;
@@ -1265,8 +1265,8 @@ static uint8_t cpl_bitaddr(struct em8051 *aCPU)
     {
         // Data sheet does not explicitly say that the modification source
         // is read from output latch, but we'll assume that is what happens.
-        bool bit = address & 7;
-        uint8_t bitmask = (1 << bit);
+        uint8_t bitaddr = address & 7;
+        uint8_t bitmask = (1 << bitaddr);
         address &= 0xf8;        
         aCPU->mSFR[address - 0x80] ^= bitmask;
         if (aCPU->sfrwrite[address - 0x80])
@@ -1274,8 +1274,8 @@ static uint8_t cpl_bitaddr(struct em8051 *aCPU)
     }
     else
     {
-        bool bit = address & 7;
-        uint8_t bitmask = (1 << bit);
+        uint8_t bitaddr = address & 7;
+        uint8_t bitmask = (1 << bitaddr);
         address >>= 3;
         address += 0x20;
         aCPU->mLowerData[address] ^= bitmask;
@@ -1403,8 +1403,8 @@ static uint8_t clr_bitaddr(struct em8051 *aCPU)
     {
         // Data sheet does not explicitly say that the modification source
         // is read from output latch, but we'll assume that is what happens.
-        bool bit = address & 7;
-        uint8_t bitmask = (1 << bit);
+        uint8_t bitaddr = address & 7;
+        uint8_t bitmask = (1 << bitaddr);
         address &= 0xf8;        
         aCPU->mSFR[address - 0x80] &= ~bitmask;
         if (aCPU->sfrwrite[address - 0x80])
@@ -1412,8 +1412,8 @@ static uint8_t clr_bitaddr(struct em8051 *aCPU)
     }
     else
     {
-        bool bit = address & 7;
-        uint8_t bitmask = (1 << bit);
+        uint8_t bitaddr = address & 7;
+        uint8_t bitmask = (1 << bitaddr);
         address >>= 3;
         address += 0x20;
         aCPU->mLowerData[address] &= ~bitmask;
@@ -1505,8 +1505,8 @@ static uint8_t setb_bitaddr(struct em8051 *aCPU)
     {
         // Data sheet does not explicitly say that the modification source
         // is read from output latch, but we'll assume that is what happens.
-        bool bit = address & 7;
-        uint8_t bitmask = (1 << bit);
+        uint8_t bitaddr = address & 7;
+        uint8_t bitmask = (1 << bitaddr);
         address &= 0xf8;        
         aCPU->mSFR[address - 0x80] |= bitmask;
         if (aCPU->sfrwrite[address - 0x80])
@@ -1514,8 +1514,8 @@ static uint8_t setb_bitaddr(struct em8051 *aCPU)
     }
     else
     {
-        bool bit = address & 7;
-        uint8_t bitmask = (1 << bit);
+        uint8_t bitaddr = address & 7;
+        uint8_t bitmask = (1 << bitaddr);
         address >>= 3;
         address += 0x20;
         aCPU->mLowerData[address] |= bitmask;

--- a/opcodes.c
+++ b/opcodes.c
@@ -112,26 +112,26 @@ static uint8_t pop_from_stack(struct em8051 *aCPU)
 }
 
 
-static void add_solve_flags(struct em8051 * aCPU, uint8_t value1, uint8_t value2, uint8_t acc)
+static void add_solve_flags(struct em8051 * aCPU, uint8_t value1, uint8_t value2, uint8_t carryin)
 {
     /* Carry: overflow from 7th bit to 8th bit */
-    uint8_t carry = ((value1 & 255) + (value2 & 255) + acc) >> 8;
+    uint8_t carry = ((value1 & 255) + (value2 & 255) + carryin) >> 8;
     
     /* Auxiliary carry: overflow from 3th bit to 4th bit */
-    uint8_t auxcarry = ((value1 & 7) + (value2 & 7) + acc) >> 3;
+    uint8_t auxcarry = ((value1 & 7) + (value2 & 7) + carryin) >> 3;
     
     /* Overflow: overflow from 6th or 7th bit, but not both */
-    uint8_t overflow = (((value1 & 127) + (value2 & 127) + acc) >> 7)^carry;
+    uint8_t overflow = (((value1 & 127) + (value2 & 127) + carryin) >> 7)^carry;
     
     PSW = (PSW & ~(PSWMASK_C | PSWMASK_AC | PSWMASK_OV)) |
           (carry << PSW_C) | (auxcarry << PSW_AC) | (overflow << PSW_OV);
 }
 
-static void sub_solve_flags(struct em8051 * aCPU, uint8_t value1, uint8_t value2, uint8_t acc)
+static void sub_solve_flags(struct em8051 * aCPU, uint8_t value1, uint8_t value2, uint8_t carryin)
 {
-    uint8_t carry = (((value1 & 255) - (value2 & 255) - acc) >> 8) & 1;
-    uint8_t auxcarry = (((value1 & 7) - (value2 & 7) - acc) >> 3) & 1;
-    uint8_t overflow = ((((value1 & 127) - (value2 & 127) - acc) >> 7) & 1)^carry;
+    uint8_t carry = (((value1 & 255) - (value2 & 255) - carryin) >> 8) & 1;
+    uint8_t auxcarry = (((value1 & 7) - (value2 & 7) - carryin) >> 3) & 1;
+    uint8_t overflow = ((((value1 & 127) - (value2 & 127) - carryin) >> 7) & 1)^carry;
     PSW = (PSW & ~(PSWMASK_C|PSWMASK_AC|PSWMASK_OV)) |
                           (carry << PSW_C) | (auxcarry << PSW_AC) | (overflow << PSW_OV);
 }


### PR DESCRIPTION
Let's use the real integer size.

Since we are emulating an 8-bit CPU on a usually bigger one, we just let
the compiler handle the necessary optimisations if integer promotion is
useful.

But then we also let the compiler ensure that there's no overflow or
wrong type size. This is specially important when we do integer
arithmetics