### PR TITLE
Enable -Wshadow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BIN := emu
 
 CFLAGS += -O2
 CFLAGS += -pipe
-CFLAGS += -g -Wall -Wextra -Wno-unused-parameter
+CFLAGS += -g -Wall -Wextra -Wno-unused-parameter -Wshadow
 
 # Uncomment to activate LTO
 #CFLAGS += -flto

--- a/emu.c
+++ b/emu.c
@@ -92,9 +92,9 @@ void emu_sleep(int value)
 #endif
 }
 
-void setSpeed(int speed, int runmode)
+void setSpeed(int aSpeed, int aRunmode)
 {
-    switch (speed)
+    switch (aSpeed)
     {
     case 7:
         slk_set(5, "+/-|.5Hz", 0);
@@ -122,7 +122,7 @@ void setSpeed(int speed, int runmode)
         break;
     }
 
-    if (runmode == 0)
+    if (aRunmode == 0)
     {
         slk_set(4, "r)un", 0);
         slk_refresh();
@@ -137,7 +137,7 @@ void setSpeed(int speed, int runmode)
         slk_refresh();
     }
 
-    if (speed < 4)
+    if (aSpeed < 4)
     {
         nocbreak();
         cbreak();
@@ -145,7 +145,7 @@ void setSpeed(int speed, int runmode)
     }
     else
     {
-        switch(speed)
+        switch(aSpeed)
         {
         case 7:
             halfdelay(20);

--- a/mainview.c
+++ b/mainview.c
@@ -599,9 +599,9 @@ void mainview_update(struct em8051 *aCPU)
 
     // convert the buffer to printable chars
     char serial_buffer[sizeof(aCPU->serial_out)];
-    for (size_t i = 0; i < sizeof(serial_buffer); i ++) {
-        char c = aCPU->serial_out[i];
-        serial_buffer[i] = isprint(c) ? c : '_';
+    for (size_t j = 0; j < sizeof(serial_buffer); j ++) {
+        char c = aCPU->serial_out[j];
+        serial_buffer[j] = isprint(c) ? c : '_';
     }
     {
         char c = aCPU->mSFR[REG_SBUF]; c = isprint(c) ? c : '_';


### PR DESCRIPTION
Shadowing variables is usually a very bad practice, as it can lead to
subtle bugs that are very hard to debug.