### PR TITLE
Use only a single static CPU

### DIFF
--- a/disasm.c
+++ b/disasm.c
@@ -34,7 +34,7 @@
 #include <string.h>
 #include "emu8051.h"
 
-#define CODEMEM(x) aCPU->mCodeMem[(x)&(aCPU->mCodeMemMaxIdx)]
+#define CODEMEM(x) CPU.mCodeMem[(x)&(CPU.mCodeMemMaxIdx)]
 #define OPCODE CODEMEM(aPosition + 0)
 #define OPERAND1 CODEMEM(aPosition + 1)
 #define OPERAND2 CODEMEM(aPosition + 2)
@@ -224,7 +224,7 @@ void bitaddr_memonic(int aValue, char *aBuffer)
 }
 
 
-static uint8_t disasm_ajmp_offset(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_ajmp_offset(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"AJMP  #%04Xh",
         ((aPosition + 2) & 0xf800) |
@@ -233,7 +233,7 @@ static uint8_t disasm_ajmp_offset(struct em8051 *aCPU, uint16_t aPosition, char 
     return 2;
 }
 
-static uint8_t disasm_ljmp_address(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_ljmp_address(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"LJMP  #%04Xh",        
         (OPERAND1 << 8) |
@@ -241,19 +241,19 @@ static uint8_t disasm_ljmp_address(struct em8051 *aCPU, uint16_t aPosition, char
     return 3;
 }
 
-static uint8_t disasm_rr_a(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_rr_a(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"RR    A");
     return 1;
 }
 
-static uint8_t disasm_inc_a(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_inc_a(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"INC   A");
     return 1;
 }
 
-static uint8_t disasm_inc_mem(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_inc_mem(uint16_t aPosition, char *aBuffer)
 {
     char mem[16];mem_memonic(OPERAND1, mem);
     sprintf(aBuffer,"INC   %s",        
@@ -262,14 +262,14 @@ static uint8_t disasm_inc_mem(struct em8051 *aCPU, uint16_t aPosition, char *aBu
     return 2;
 }
 
-static uint8_t disasm_inc_indir_rx(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_inc_indir_rx(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"INC   @R%d",        
         OPCODE & 1);
     return 1;
 }
 
-static uint8_t disasm_jbc_bitaddr_offset(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_jbc_bitaddr_offset(uint16_t aPosition, char *aBuffer)
 {
     char baddr[16];
     bitaddr_memonic(OPERAND1, baddr);
@@ -279,7 +279,7 @@ static uint8_t disasm_jbc_bitaddr_offset(struct em8051 *aCPU, uint16_t aPosition
     return 3;
 }
 
-static uint8_t disasm_acall_offset(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_acall_offset(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"ACALL %04Xh",
         ((aPosition + 2) & 0xf800) |
@@ -288,7 +288,7 @@ static uint8_t disasm_acall_offset(struct em8051 *aCPU, uint16_t aPosition, char
     return 2;
 }
 
-static uint8_t disasm_lcall_address(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_lcall_address(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"LCALL #%04Xh",        
         (OPERAND1 << 8) |
@@ -296,19 +296,19 @@ static uint8_t disasm_lcall_address(struct em8051 *aCPU, uint16_t aPosition, cha
     return 3;
 }
 
-static uint8_t disasm_rrc_a(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_rrc_a(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"RRC   A");
     return 1;
 }
 
-static uint8_t disasm_dec_a(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_dec_a(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"DEC   A");
     return 1;
 }
 
-static uint8_t disasm_dec_mem(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_dec_mem(uint16_t aPosition, char *aBuffer)
 {
     char mem[16];mem_memonic(OPERAND1, mem);
     sprintf(aBuffer,"DEC   %s",        
@@ -317,7 +317,7 @@ static uint8_t disasm_dec_mem(struct em8051 *aCPU, uint16_t aPosition, char *aBu
     return 2;
 }
 
-static uint8_t disasm_dec_indir_rx(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_dec_indir_rx(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"DEC   @R%d",        
         OPCODE & 1);
@@ -325,7 +325,7 @@ static uint8_t disasm_dec_indir_rx(struct em8051 *aCPU, uint16_t aPosition, char
 }
 
 
-static uint8_t disasm_jb_bitaddr_offset(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_jb_bitaddr_offset(uint16_t aPosition, char *aBuffer)
 {
     char baddr[16];
     bitaddr_memonic(OPERAND1, baddr);
@@ -335,26 +335,26 @@ static uint8_t disasm_jb_bitaddr_offset(struct em8051 *aCPU, uint16_t aPosition,
     return 3;
 }
 
-static uint8_t disasm_ret(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_ret(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"RET");
     return 1;
 }
 
-static uint8_t disasm_rl_a(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_rl_a(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"RL    A");
     return 1;
 }
 
-static uint8_t disasm_add_a_imm(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_add_a_imm(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"ADD   A, #%02Xh",        
         OPERAND1);
     return 2;
 }
 
-static uint8_t disasm_add_a_mem(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_add_a_mem(uint16_t aPosition, char *aBuffer)
 {
     char mem[16];mem_memonic(OPERAND1, mem);
     sprintf(aBuffer,"ADD   A, %s",        
@@ -363,14 +363,14 @@ static uint8_t disasm_add_a_mem(struct em8051 *aCPU, uint16_t aPosition, char *a
     return 2;
 }
 
-static uint8_t disasm_add_a_indir_rx(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_add_a_indir_rx(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"ADD   A, @R%d",        
         OPCODE&1);
     return 1;
 }
 
-static uint8_t disasm_jnb_bitaddr_offset(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_jnb_bitaddr_offset(uint16_t aPosition, char *aBuffer)
 {
     char baddr[16];
     bitaddr_memonic(OPERAND1, baddr);
@@ -380,26 +380,26 @@ static uint8_t disasm_jnb_bitaddr_offset(struct em8051 *aCPU, uint16_t aPosition
     return 3;
 }
 
-static uint8_t disasm_reti(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_reti(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"RETI");
     return 1;
 }
 
-static uint8_t disasm_rlc_a(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_rlc_a(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"RLC   A");
     return 1;
 }
 
-static uint8_t disasm_addc_a_imm(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_addc_a_imm(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"ADDC  A, #%02Xh",        
         OPERAND1);
     return 2;
 }
 
-static uint8_t disasm_addc_a_mem(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_addc_a_mem(uint16_t aPosition, char *aBuffer)
 {
     char mem[16];mem_memonic(OPERAND1, mem);
     sprintf(aBuffer,"ADDC  A, %s",        
@@ -408,7 +408,7 @@ static uint8_t disasm_addc_a_mem(struct em8051 *aCPU, uint16_t aPosition, char *
     return 2;
 }
 
-static uint8_t disasm_addc_a_indir_rx(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_addc_a_indir_rx(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"ADDC  A, @R%d",        
         OPCODE&1);
@@ -416,14 +416,14 @@ static uint8_t disasm_addc_a_indir_rx(struct em8051 *aCPU, uint16_t aPosition, c
 }
 
 
-static uint8_t disasm_jc_offset(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_jc_offset(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"JC    #%+d",        
         (signed char)OPERAND1);
     return 2;
 }
 
-static uint8_t disasm_orl_mem_a(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_orl_mem_a(uint16_t aPosition, char *aBuffer)
 {
     char mem[16];mem_memonic(OPERAND1, mem);
     sprintf(aBuffer,"ORL   %s, A",        
@@ -432,7 +432,7 @@ static uint8_t disasm_orl_mem_a(struct em8051 *aCPU, uint16_t aPosition, char *a
     return 2;
 }
 
-static uint8_t disasm_orl_mem_imm(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_orl_mem_imm(uint16_t aPosition, char *aBuffer)
 {
     char mem[16];mem_memonic(OPERAND1, mem);
     sprintf(aBuffer,"ORL   %s, #%02Xh",        
@@ -442,14 +442,14 @@ static uint8_t disasm_orl_mem_imm(struct em8051 *aCPU, uint16_t aPosition, char 
     return 3;
 }
 
-static uint8_t disasm_orl_a_imm(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_orl_a_imm(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"ORL   A, #%02Xh",        
         OPERAND1);
     return 2;
 }
 
-static uint8_t disasm_orl_a_mem(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_orl_a_mem(uint16_t aPosition, char *aBuffer)
 {
     char mem[16];mem_memonic(OPERAND1, mem);
     sprintf(aBuffer,"ORL   A, %s",        
@@ -458,7 +458,7 @@ static uint8_t disasm_orl_a_mem(struct em8051 *aCPU, uint16_t aPosition, char *a
     return 2;
 }
 
-static uint8_t disasm_orl_a_indir_rx(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_orl_a_indir_rx(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"ORL   A, @R%d",        
         OPCODE&1);
@@ -466,14 +466,14 @@ static uint8_t disasm_orl_a_indir_rx(struct em8051 *aCPU, uint16_t aPosition, ch
 }
 
 
-static uint8_t disasm_jnc_offset(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_jnc_offset(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"JNC   #%+d",        
         (signed char)OPERAND1);
     return 2;
 }
 
-static uint8_t disasm_anl_mem_a(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_anl_mem_a(uint16_t aPosition, char *aBuffer)
 {
     char mem[16];mem_memonic(OPERAND1, mem);
     sprintf(aBuffer,"ANL   %s, A",
@@ -482,7 +482,7 @@ static uint8_t disasm_anl_mem_a(struct em8051 *aCPU, uint16_t aPosition, char *a
     return 2;
 }
 
-static uint8_t disasm_anl_mem_imm(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_anl_mem_imm(uint16_t aPosition, char *aBuffer)
 {
     char mem[16];mem_memonic(OPERAND1, mem);
     sprintf(aBuffer,"ANL   %s, #%02Xh",        
@@ -492,14 +492,14 @@ static uint8_t disasm_anl_mem_imm(struct em8051 *aCPU, uint16_t aPosition, char 
     return 3;
 }
 
-static uint8_t disasm_anl_a_imm(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_anl_a_imm(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"ANL   A, #%02Xh",
         OPERAND1);
     return 2;
 }
 
-static uint8_t disasm_anl_a_mem(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_anl_a_mem(uint16_t aPosition, char *aBuffer)
 {
     char mem[16];mem_memonic(OPERAND1, mem);
     sprintf(aBuffer,"ANL   A, %s",
@@ -508,7 +508,7 @@ static uint8_t disasm_anl_a_mem(struct em8051 *aCPU, uint16_t aPosition, char *a
     return 2;
 }
 
-static uint8_t disasm_anl_a_indir_rx(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_anl_a_indir_rx(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"ANL   A, @R%d",        
         OPCODE&1);
@@ -516,14 +516,14 @@ static uint8_t disasm_anl_a_indir_rx(struct em8051 *aCPU, uint16_t aPosition, ch
 }
 
 
-static uint8_t disasm_jz_offset(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_jz_offset(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"JZ    #%+d",        
         (signed char)OPERAND1);
     return 2;
 }
 
-static uint8_t disasm_xrl_mem_a(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_xrl_mem_a(uint16_t aPosition, char *aBuffer)
 {
     char mem[16];mem_memonic(OPERAND1, mem);
     sprintf(aBuffer,"XRL   %s, A",
@@ -532,7 +532,7 @@ static uint8_t disasm_xrl_mem_a(struct em8051 *aCPU, uint16_t aPosition, char *a
     return 2;
 }
 
-static uint8_t disasm_xrl_mem_imm(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_xrl_mem_imm(uint16_t aPosition, char *aBuffer)
 {
     char mem[16];mem_memonic(OPERAND1, mem);
     sprintf(aBuffer,"XRL   %s, #%02Xh",        
@@ -542,14 +542,14 @@ static uint8_t disasm_xrl_mem_imm(struct em8051 *aCPU, uint16_t aPosition, char 
     return 3;
 }
 
-static uint8_t disasm_xrl_a_imm(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_xrl_a_imm(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"XRL   A, #%02Xh",
         OPERAND1);
     return 2;
 }
 
-static uint8_t disasm_xrl_a_mem(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_xrl_a_mem(uint16_t aPosition, char *aBuffer)
 {
     char mem[16];mem_memonic(OPERAND1, mem);
     sprintf(aBuffer,"XRL   A, %s",
@@ -558,7 +558,7 @@ static uint8_t disasm_xrl_a_mem(struct em8051 *aCPU, uint16_t aPosition, char *a
     return 2;
 }
 
-static uint8_t disasm_xrl_a_indir_rx(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_xrl_a_indir_rx(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"XRL   A, @R%d",        
         OPCODE&1);
@@ -566,14 +566,14 @@ static uint8_t disasm_xrl_a_indir_rx(struct em8051 *aCPU, uint16_t aPosition, ch
 }
 
 
-static uint8_t disasm_jnz_offset(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_jnz_offset(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"JNZ   #%+d",        
         (signed char)OPERAND1);
     return 2;
 }
 
-static uint8_t disasm_orl_c_bitaddr(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_orl_c_bitaddr(uint16_t aPosition, char *aBuffer)
 {
     char baddr[16];
     bitaddr_memonic(OPERAND1, baddr);
@@ -582,20 +582,20 @@ static uint8_t disasm_orl_c_bitaddr(struct em8051 *aCPU, uint16_t aPosition, cha
     return 2;
 }
 
-static uint8_t disasm_jmp_indir_a_dptr(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_jmp_indir_a_dptr(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"JMP   @A+DPTR");
     return 1;
 }
 
-static uint8_t disasm_mov_a_imm(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_mov_a_imm(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"MOV   A, #%02Xh",
         OPERAND1);
     return 2;
 }
 
-static uint8_t disasm_mov_mem_imm(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_mov_mem_imm(uint16_t aPosition, char *aBuffer)
 {
     char mem[16];mem_memonic(OPERAND1, mem);
     sprintf(aBuffer,"MOV   %s, #%02Xh",        
@@ -605,7 +605,7 @@ static uint8_t disasm_mov_mem_imm(struct em8051 *aCPU, uint16_t aPosition, char 
     return 3;
 }
 
-static uint8_t disasm_mov_indir_rx_imm(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_mov_indir_rx_imm(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"MOV   @R%d, #%02Xh",        
         OPCODE&1,
@@ -614,14 +614,14 @@ static uint8_t disasm_mov_indir_rx_imm(struct em8051 *aCPU, uint16_t aPosition, 
 }
 
 
-static uint8_t disasm_sjmp_offset(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_sjmp_offset(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"SJMP  #%+d",        
         (signed char)(OPERAND1));
     return 2;
 }
 
-static uint8_t disasm_anl_c_bitaddr(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_anl_c_bitaddr(uint16_t aPosition, char *aBuffer)
 {
     char baddr[16];
     bitaddr_memonic(OPERAND1, baddr);
@@ -630,19 +630,19 @@ static uint8_t disasm_anl_c_bitaddr(struct em8051 *aCPU, uint16_t aPosition, cha
     return 2;
 }
 
-static uint8_t disasm_movc_a_indir_a_pc(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_movc_a_indir_a_pc(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"MOVC  A, @A+PC");
     return 1;
 }
 
-static uint8_t disasm_div_ab(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_div_ab(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"DIV   AB");
     return 1;
 }
 
-static uint8_t disasm_mov_mem_mem(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_mov_mem_mem(uint16_t aPosition, char *aBuffer)
 {
     char mem1[16];
     char mem2[16];
@@ -654,7 +654,7 @@ static uint8_t disasm_mov_mem_mem(struct em8051 *aCPU, uint16_t aPosition, char 
     return 3;
 }
 
-static uint8_t disasm_mov_mem_indir_rx(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_mov_mem_indir_rx(uint16_t aPosition, char *aBuffer)
 {
     char mem[16];mem_memonic(OPERAND1, mem);
     sprintf(aBuffer,"MOV   %s, @R%d",        
@@ -665,7 +665,7 @@ static uint8_t disasm_mov_mem_indir_rx(struct em8051 *aCPU, uint16_t aPosition, 
 }
 
 
-static uint8_t disasm_mov_dptr_imm(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_mov_dptr_imm(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"MOV   DPTR, #0%02X%02Xh",        
         OPERAND1,
@@ -673,7 +673,7 @@ static uint8_t disasm_mov_dptr_imm(struct em8051 *aCPU, uint16_t aPosition, char
     return 3;
 }
 
-static uint8_t disasm_mov_bitaddr_c(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_mov_bitaddr_c(uint16_t aPosition, char *aBuffer)
 {
     char baddr[16];
     bitaddr_memonic(OPERAND1, baddr);
@@ -682,20 +682,20 @@ static uint8_t disasm_mov_bitaddr_c(struct em8051 *aCPU, uint16_t aPosition, cha
     return 2;
 }
 
-static uint8_t disasm_movc_a_indir_a_dptr(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_movc_a_indir_a_dptr(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"MOVC  A, @A+DPTR");
     return 1;
 }
 
-static uint8_t disasm_subb_a_imm(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_subb_a_imm(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"SUBB  A, #%02Xh",
         OPERAND1);
     return 2;
 }
 
-static uint8_t disasm_subb_a_mem(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_subb_a_mem(uint16_t aPosition, char *aBuffer)
 {
     char mem[16];mem_memonic(OPERAND1, mem);
     sprintf(aBuffer,"SUBB  A, %s",
@@ -703,7 +703,7 @@ static uint8_t disasm_subb_a_mem(struct em8051 *aCPU, uint16_t aPosition, char *
     
     return 2;
 }
-static uint8_t disasm_subb_a_indir_rx(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_subb_a_indir_rx(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"SUBB  A, @R%d",        
         OPCODE&1);
@@ -711,7 +711,7 @@ static uint8_t disasm_subb_a_indir_rx(struct em8051 *aCPU, uint16_t aPosition, c
 }
 
 
-static uint8_t disasm_orl_c_compl_bitaddr(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_orl_c_compl_bitaddr(uint16_t aPosition, char *aBuffer)
 {
     char baddr[16];
     bitaddr_memonic(OPERAND1, baddr);
@@ -720,7 +720,7 @@ static uint8_t disasm_orl_c_compl_bitaddr(struct em8051 *aCPU, uint16_t aPositio
     return 2;
 }
 
-static uint8_t disasm_mov_c_bitaddr(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_mov_c_bitaddr(uint16_t aPosition, char *aBuffer)
 {
     char baddr[16];
     bitaddr_memonic(OPERAND1, baddr);
@@ -729,19 +729,19 @@ static uint8_t disasm_mov_c_bitaddr(struct em8051 *aCPU, uint16_t aPosition, cha
     return 2;
 }
 
-static uint8_t disasm_inc_dptr(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_inc_dptr(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"INC   DPTR");
     return 1;
 }
 
-static uint8_t disasm_mul_ab(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_mul_ab(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"MUL   AB");
     return 1;
 }
 
-static uint8_t disasm_mov_indir_rx_mem(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_mov_indir_rx_mem(uint16_t aPosition, char *aBuffer)
 {
     char mem[16];mem_memonic(OPERAND1, mem);
     sprintf(aBuffer,"MOV   @R%d, %s",        
@@ -752,7 +752,7 @@ static uint8_t disasm_mov_indir_rx_mem(struct em8051 *aCPU, uint16_t aPosition, 
 }
 
 
-static uint8_t disasm_anl_c_compl_bitaddr(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_anl_c_compl_bitaddr(uint16_t aPosition, char *aBuffer)
 {
     char baddr[16];
     bitaddr_memonic(OPERAND1, baddr);
@@ -762,7 +762,7 @@ static uint8_t disasm_anl_c_compl_bitaddr(struct em8051 *aCPU, uint16_t aPositio
 }
 
 
-static uint8_t disasm_cpl_bitaddr(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_cpl_bitaddr(uint16_t aPosition, char *aBuffer)
 {
     char baddr[16];
     bitaddr_memonic(OPERAND1, baddr);
@@ -771,13 +771,13 @@ static uint8_t disasm_cpl_bitaddr(struct em8051 *aCPU, uint16_t aPosition, char 
     return 2;
 }
 
-static uint8_t disasm_cpl_c(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_cpl_c(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"CPL   C");
     return 1;
 }
 
-static uint8_t disasm_cjne_a_imm_offset(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_cjne_a_imm_offset(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"CJNE  A, #%02Xh, #%+d",
         OPERAND1,
@@ -785,7 +785,7 @@ static uint8_t disasm_cjne_a_imm_offset(struct em8051 *aCPU, uint16_t aPosition,
     return 3;
 }
 
-static uint8_t disasm_cjne_a_mem_offset(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_cjne_a_mem_offset(uint16_t aPosition, char *aBuffer)
 {
     char mem[16];mem_memonic(OPERAND1, mem);
     sprintf(aBuffer,"CJNE  A, %s, #%+d",
@@ -794,7 +794,7 @@ static uint8_t disasm_cjne_a_mem_offset(struct em8051 *aCPU, uint16_t aPosition,
     
     return 3;
 }
-static uint8_t disasm_cjne_indir_rx_imm_offset(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_cjne_indir_rx_imm_offset(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"CJNE  @R%d, #%02Xh, #%+d",
         OPCODE&1,
@@ -803,7 +803,7 @@ static uint8_t disasm_cjne_indir_rx_imm_offset(struct em8051 *aCPU, uint16_t aPo
     return 3;
 }
 
-static uint8_t disasm_push_mem(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_push_mem(uint16_t aPosition, char *aBuffer)
 {
     char mem[16];mem_memonic(OPERAND1, mem);
     sprintf(aBuffer,"PUSH  %s",
@@ -813,7 +813,7 @@ static uint8_t disasm_push_mem(struct em8051 *aCPU, uint16_t aPosition, char *aB
 }
 
 
-static uint8_t disasm_clr_bitaddr(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_clr_bitaddr(uint16_t aPosition, char *aBuffer)
 {
     char baddr[16];
     bitaddr_memonic(OPERAND1, baddr);
@@ -822,19 +822,19 @@ static uint8_t disasm_clr_bitaddr(struct em8051 *aCPU, uint16_t aPosition, char 
     return 2;
 }
 
-static uint8_t disasm_clr_c(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_clr_c(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"CLR   C");
     return 1;
 }
 
-static uint8_t disasm_swap_a(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_swap_a(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"SWAP  A");
     return 1;
 }
 
-static uint8_t disasm_xch_a_mem(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_xch_a_mem(uint16_t aPosition, char *aBuffer)
 {
     char mem[16];mem_memonic(OPERAND1, mem);
     sprintf(aBuffer,"XCH   A, %s",
@@ -843,7 +843,7 @@ static uint8_t disasm_xch_a_mem(struct em8051 *aCPU, uint16_t aPosition, char *a
     return 2;
 }
 
-static uint8_t disasm_xch_a_indir_rx(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_xch_a_indir_rx(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"XCH   A, @R%d",        
         OPCODE&1);
@@ -851,7 +851,7 @@ static uint8_t disasm_xch_a_indir_rx(struct em8051 *aCPU, uint16_t aPosition, ch
 }
 
 
-static uint8_t disasm_pop_mem(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_pop_mem(uint16_t aPosition, char *aBuffer)
 {
     char mem[16];mem_memonic(OPERAND1, mem);
     sprintf(aBuffer,"POP   %s",
@@ -860,7 +860,7 @@ static uint8_t disasm_pop_mem(struct em8051 *aCPU, uint16_t aPosition, char *aBu
     return 2;
 }
 
-static uint8_t disasm_setb_bitaddr(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_setb_bitaddr(uint16_t aPosition, char *aBuffer)
 {
     char baddr[16];
     bitaddr_memonic(OPERAND1, baddr);
@@ -869,19 +869,19 @@ static uint8_t disasm_setb_bitaddr(struct em8051 *aCPU, uint16_t aPosition, char
     return 2;
 }
 
-static uint8_t disasm_setb_c(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_setb_c(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"SETB  C");
     return 1;
 }
 
-static uint8_t disasm_da_a(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_da_a(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"DA    A");
     return 1;
 }
 
-static uint8_t disasm_djnz_mem_offset(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_djnz_mem_offset(uint16_t aPosition, char *aBuffer)
 {
     char mem[16];mem_memonic(OPERAND1, mem);
     sprintf(aBuffer,"DJNZ  %s, #%+d",        
@@ -890,7 +890,7 @@ static uint8_t disasm_djnz_mem_offset(struct em8051 *aCPU, uint16_t aPosition, c
     return 3;
 }
 
-static uint8_t disasm_xchd_a_indir_rx(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_xchd_a_indir_rx(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"XCHD  A, @R%d",        
         OPCODE&1);
@@ -898,26 +898,26 @@ static uint8_t disasm_xchd_a_indir_rx(struct em8051 *aCPU, uint16_t aPosition, c
 }
 
 
-static uint8_t disasm_movx_a_indir_dptr(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_movx_a_indir_dptr(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"MOVX  A, @DPTR");
     return 1;
 }
 
-static uint8_t disasm_movx_a_indir_rx(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_movx_a_indir_rx(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"MOVX  A, @R%d",        
         OPCODE&1);
     return 1;
 }
 
-static uint8_t disasm_clr_a(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_clr_a(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"CLR   A");
     return 1;
 }
 
-static uint8_t disasm_mov_a_mem(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_mov_a_mem(uint16_t aPosition, char *aBuffer)
 {
     char mem[16];mem_memonic(OPERAND1, mem);
     sprintf(aBuffer,"MOV   A, %s",
@@ -926,7 +926,7 @@ static uint8_t disasm_mov_a_mem(struct em8051 *aCPU, uint16_t aPosition, char *a
     return 2;
 }
 
-static uint8_t disasm_mov_a_indir_rx(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_mov_a_indir_rx(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"MOV   A, @R%d",        
         OPCODE&1);
@@ -934,26 +934,26 @@ static uint8_t disasm_mov_a_indir_rx(struct em8051 *aCPU, uint16_t aPosition, ch
 }
 
 
-static uint8_t disasm_movx_indir_dptr_a(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_movx_indir_dptr_a(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"MOVX  @DPTR, A");
     return 1;
 }
 
-static uint8_t disasm_movx_indir_rx_a(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_movx_indir_rx_a(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"MOVX  @R%d, A",        
         OPCODE&1);
     return 1;
 }
 
-static uint8_t disasm_cpl_a(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_cpl_a(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"CPL   A");
     return 1;
 }
 
-static uint8_t disasm_mov_mem_a(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_mov_mem_a(uint16_t aPosition, char *aBuffer)
 {
     char mem[16];mem_memonic(OPERAND1, mem);
     sprintf(aBuffer,"MOV   %s, A",
@@ -962,14 +962,14 @@ static uint8_t disasm_mov_mem_a(struct em8051 *aCPU, uint16_t aPosition, char *a
     return 2;
 }
 
-static uint8_t disasm_mov_indir_rx_a(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_mov_indir_rx_a(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"MOV   @R%d, A",
         OPCODE&1);
     return 1;
 }
 
-static uint8_t disasm_nop(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_nop(uint16_t aPosition, char *aBuffer)
 {
     if (OPCODE)
         sprintf(aBuffer,"??UNKNOWN");
@@ -978,50 +978,50 @@ static uint8_t disasm_nop(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer
     return 1;
 }
 
-static uint8_t disasm_inc_rx(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_inc_rx(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"INC   R%d",OPCODE&7);
     return 1;
 }
 
-static uint8_t disasm_dec_rx(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_dec_rx(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"DEC   R%d",OPCODE&7);
     return 1;
 }
 
-static uint8_t disasm_add_a_rx(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_add_a_rx(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"ADD   A, R%d",OPCODE&7);
     return 1;
 }
 
-static uint8_t disasm_addc_a_rx(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_addc_a_rx(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"ADDC  A, R%d",OPCODE&7);
     return 1;
 }
 
-static uint8_t disasm_orl_a_rx(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_orl_a_rx(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"ORL   A, R%d",OPCODE&7);
     return 1;
 }
 
-static uint8_t disasm_anl_a_rx(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_anl_a_rx(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"ANL   A, R%d",OPCODE&7);
     return 1;
 }
 
-static uint8_t disasm_xrl_a_rx(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_xrl_a_rx(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"XRL   A, R%d",OPCODE&7);
     return 1;
 }
 
 
-static uint8_t disasm_mov_rx_imm(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_mov_rx_imm(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"MOV   R%d, #%02Xh",
         OPCODE&7,
@@ -1029,7 +1029,7 @@ static uint8_t disasm_mov_rx_imm(struct em8051 *aCPU, uint16_t aPosition, char *
     return 2;
 }
 
-static uint8_t disasm_mov_mem_rx(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_mov_mem_rx(uint16_t aPosition, char *aBuffer)
 {
     char mem[16];mem_memonic(OPERAND1, mem);
     sprintf(aBuffer,"MOV   %s, R%d",
@@ -1039,13 +1039,13 @@ static uint8_t disasm_mov_mem_rx(struct em8051 *aCPU, uint16_t aPosition, char *
     return 2;
 }
 
-static uint8_t disasm_subb_a_rx(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_subb_a_rx(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"SUBB  A, R%d",OPCODE&7);
     return 1;
 }
 
-static uint8_t disasm_mov_rx_mem(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_mov_rx_mem(uint16_t aPosition, char *aBuffer)
 {
     char mem[16];mem_memonic(OPERAND1, mem);
     sprintf(aBuffer,"MOV   R%d, %s",
@@ -1055,7 +1055,7 @@ static uint8_t disasm_mov_rx_mem(struct em8051 *aCPU, uint16_t aPosition, char *
     return 2;
 }
 
-static uint8_t disasm_cjne_rx_imm_offset(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_cjne_rx_imm_offset(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"CJNE  R%d, #%02Xh, #%+d",
         OPCODE&7,
@@ -1064,13 +1064,13 @@ static uint8_t disasm_cjne_rx_imm_offset(struct em8051 *aCPU, uint16_t aPosition
     return 3;
 }
 
-static uint8_t disasm_xch_a_rx(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_xch_a_rx(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"XCH   A, R%d",OPCODE&7);
     return 1;
 }
 
-static uint8_t disasm_djnz_rx_offset(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_djnz_rx_offset(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"DJNZ  R%d, #%+d",
         OPCODE&7,
@@ -1078,181 +1078,181 @@ static uint8_t disasm_djnz_rx_offset(struct em8051 *aCPU, uint16_t aPosition, ch
     return 2;
 }
 
-static uint8_t disasm_mov_a_rx(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_mov_a_rx(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"MOV   A, R%d",OPCODE&7);
     return 1;
 }
 
-static uint8_t disasm_mov_rx_a(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+static uint8_t disasm_mov_rx_a(uint16_t aPosition, char *aBuffer)
 {
     sprintf(aBuffer,"MOV   R%d, A",OPCODE&7);
     return 1;
 }
 
-void disasm_setptrs(struct em8051 *aCPU)
+void disasm_setptrs()
 {
     int i;
     for (i = 0; i < 8; i++)
     {
-        aCPU->dec[0x08 + i] = &disasm_inc_rx;
-        aCPU->dec[0x18 + i] = &disasm_dec_rx;
-        aCPU->dec[0x28 + i] = &disasm_add_a_rx;
-        aCPU->dec[0x38 + i] = &disasm_addc_a_rx;
-        aCPU->dec[0x48 + i] = &disasm_orl_a_rx;
-        aCPU->dec[0x58 + i] = &disasm_anl_a_rx;
-        aCPU->dec[0x68 + i] = &disasm_xrl_a_rx;
-        aCPU->dec[0x78 + i] = &disasm_mov_rx_imm;
-        aCPU->dec[0x88 + i] = &disasm_mov_mem_rx;
-        aCPU->dec[0x98 + i] = &disasm_subb_a_rx;
-        aCPU->dec[0xa8 + i] = &disasm_mov_rx_mem;
-        aCPU->dec[0xb8 + i] = &disasm_cjne_rx_imm_offset;
-        aCPU->dec[0xc8 + i] = &disasm_xch_a_rx;
-        aCPU->dec[0xd8 + i] = &disasm_djnz_rx_offset;
-        aCPU->dec[0xe8 + i] = &disasm_mov_a_rx;
-        aCPU->dec[0xf8 + i] = &disasm_mov_rx_a;
+        CPU.dec[0x08 + i] = &disasm_inc_rx;
+        CPU.dec[0x18 + i] = &disasm_dec_rx;
+        CPU.dec[0x28 + i] = &disasm_add_a_rx;
+        CPU.dec[0x38 + i] = &disasm_addc_a_rx;
+        CPU.dec[0x48 + i] = &disasm_orl_a_rx;
+        CPU.dec[0x58 + i] = &disasm_anl_a_rx;
+        CPU.dec[0x68 + i] = &disasm_xrl_a_rx;
+        CPU.dec[0x78 + i] = &disasm_mov_rx_imm;
+        CPU.dec[0x88 + i] = &disasm_mov_mem_rx;
+        CPU.dec[0x98 + i] = &disasm_subb_a_rx;
+        CPU.dec[0xa8 + i] = &disasm_mov_rx_mem;
+        CPU.dec[0xb8 + i] = &disasm_cjne_rx_imm_offset;
+        CPU.dec[0xc8 + i] = &disasm_xch_a_rx;
+        CPU.dec[0xd8 + i] = &disasm_djnz_rx_offset;
+        CPU.dec[0xe8 + i] = &disasm_mov_a_rx;
+        CPU.dec[0xf8 + i] = &disasm_mov_rx_a;
     }
-    aCPU->dec[0x00] = &disasm_nop;
-    aCPU->dec[0x01] = &disasm_ajmp_offset;
-    aCPU->dec[0x02] = &disasm_ljmp_address;
-    aCPU->dec[0x03] = &disasm_rr_a;
-    aCPU->dec[0x04] = &disasm_inc_a;
-    aCPU->dec[0x05] = &disasm_inc_mem;
-    aCPU->dec[0x06] = &disasm_inc_indir_rx;
-    aCPU->dec[0x07] = &disasm_inc_indir_rx;
+    CPU.dec[0x00] = &disasm_nop;
+    CPU.dec[0x01] = &disasm_ajmp_offset;
+    CPU.dec[0x02] = &disasm_ljmp_address;
+    CPU.dec[0x03] = &disasm_rr_a;
+    CPU.dec[0x04] = &disasm_inc_a;
+    CPU.dec[0x05] = &disasm_inc_mem;
+    CPU.dec[0x06] = &disasm_inc_indir_rx;
+    CPU.dec[0x07] = &disasm_inc_indir_rx;
 
-    aCPU->dec[0x10] = &disasm_jbc_bitaddr_offset;
-    aCPU->dec[0x11] = &disasm_acall_offset;
-    aCPU->dec[0x12] = &disasm_lcall_address;
-    aCPU->dec[0x13] = &disasm_rrc_a;
-    aCPU->dec[0x14] = &disasm_dec_a;
-    aCPU->dec[0x15] = &disasm_dec_mem;
-    aCPU->dec[0x16] = &disasm_dec_indir_rx;
-    aCPU->dec[0x17] = &disasm_dec_indir_rx;
+    CPU.dec[0x10] = &disasm_jbc_bitaddr_offset;
+    CPU.dec[0x11] = &disasm_acall_offset;
+    CPU.dec[0x12] = &disasm_lcall_address;
+    CPU.dec[0x13] = &disasm_rrc_a;
+    CPU.dec[0x14] = &disasm_dec_a;
+    CPU.dec[0x15] = &disasm_dec_mem;
+    CPU.dec[0x16] = &disasm_dec_indir_rx;
+    CPU.dec[0x17] = &disasm_dec_indir_rx;
 
-    aCPU->dec[0x20] = &disasm_jb_bitaddr_offset;
-    aCPU->dec[0x21] = &disasm_ajmp_offset;
-    aCPU->dec[0x22] = &disasm_ret;
-    aCPU->dec[0x23] = &disasm_rl_a;
-    aCPU->dec[0x24] = &disasm_add_a_imm;
-    aCPU->dec[0x25] = &disasm_add_a_mem;
-    aCPU->dec[0x26] = &disasm_add_a_indir_rx;
-    aCPU->dec[0x27] = &disasm_add_a_indir_rx;
+    CPU.dec[0x20] = &disasm_jb_bitaddr_offset;
+    CPU.dec[0x21] = &disasm_ajmp_offset;
+    CPU.dec[0x22] = &disasm_ret;
+    CPU.dec[0x23] = &disasm_rl_a;
+    CPU.dec[0x24] = &disasm_add_a_imm;
+    CPU.dec[0x25] = &disasm_add_a_mem;
+    CPU.dec[0x26] = &disasm_add_a_indir_rx;
+    CPU.dec[0x27] = &disasm_add_a_indir_rx;
 
-    aCPU->dec[0x30] = &disasm_jnb_bitaddr_offset;
-    aCPU->dec[0x31] = &disasm_acall_offset;
-    aCPU->dec[0x32] = &disasm_reti;
-    aCPU->dec[0x33] = &disasm_rlc_a;
-    aCPU->dec[0x34] = &disasm_addc_a_imm;
-    aCPU->dec[0x35] = &disasm_addc_a_mem;
-    aCPU->dec[0x36] = &disasm_addc_a_indir_rx;
-    aCPU->dec[0x37] = &disasm_addc_a_indir_rx;
+    CPU.dec[0x30] = &disasm_jnb_bitaddr_offset;
+    CPU.dec[0x31] = &disasm_acall_offset;
+    CPU.dec[0x32] = &disasm_reti;
+    CPU.dec[0x33] = &disasm_rlc_a;
+    CPU.dec[0x34] = &disasm_addc_a_imm;
+    CPU.dec[0x35] = &disasm_addc_a_mem;
+    CPU.dec[0x36] = &disasm_addc_a_indir_rx;
+    CPU.dec[0x37] = &disasm_addc_a_indir_rx;
 
-    aCPU->dec[0x40] = &disasm_jc_offset;
-    aCPU->dec[0x41] = &disasm_ajmp_offset;
-    aCPU->dec[0x42] = &disasm_orl_mem_a;
-    aCPU->dec[0x43] = &disasm_orl_mem_imm;
-    aCPU->dec[0x44] = &disasm_orl_a_imm;
-    aCPU->dec[0x45] = &disasm_orl_a_mem;
-    aCPU->dec[0x46] = &disasm_orl_a_indir_rx;
-    aCPU->dec[0x47] = &disasm_orl_a_indir_rx;
+    CPU.dec[0x40] = &disasm_jc_offset;
+    CPU.dec[0x41] = &disasm_ajmp_offset;
+    CPU.dec[0x42] = &disasm_orl_mem_a;
+    CPU.dec[0x43] = &disasm_orl_mem_imm;
+    CPU.dec[0x44] = &disasm_orl_a_imm;
+    CPU.dec[0x45] = &disasm_orl_a_mem;
+    CPU.dec[0x46] = &disasm_orl_a_indir_rx;
+    CPU.dec[0x47] = &disasm_orl_a_indir_rx;
 
-    aCPU->dec[0x50] = &disasm_jnc_offset;
-    aCPU->dec[0x51] = &disasm_acall_offset;
-    aCPU->dec[0x52] = &disasm_anl_mem_a;
-    aCPU->dec[0x53] = &disasm_anl_mem_imm;
-    aCPU->dec[0x54] = &disasm_anl_a_imm;
-    aCPU->dec[0x55] = &disasm_anl_a_mem;
-    aCPU->dec[0x56] = &disasm_anl_a_indir_rx;
-    aCPU->dec[0x57] = &disasm_anl_a_indir_rx;
+    CPU.dec[0x50] = &disasm_jnc_offset;
+    CPU.dec[0x51] = &disasm_acall_offset;
+    CPU.dec[0x52] = &disasm_anl_mem_a;
+    CPU.dec[0x53] = &disasm_anl_mem_imm;
+    CPU.dec[0x54] = &disasm_anl_a_imm;
+    CPU.dec[0x55] = &disasm_anl_a_mem;
+    CPU.dec[0x56] = &disasm_anl_a_indir_rx;
+    CPU.dec[0x57] = &disasm_anl_a_indir_rx;
 
-    aCPU->dec[0x60] = &disasm_jz_offset;
-    aCPU->dec[0x61] = &disasm_ajmp_offset;
-    aCPU->dec[0x62] = &disasm_xrl_mem_a;
-    aCPU->dec[0x63] = &disasm_xrl_mem_imm;
-    aCPU->dec[0x64] = &disasm_xrl_a_imm;
-    aCPU->dec[0x65] = &disasm_xrl_a_mem;
-    aCPU->dec[0x66] = &disasm_xrl_a_indir_rx;
-    aCPU->dec[0x67] = &disasm_xrl_a_indir_rx;
+    CPU.dec[0x60] = &disasm_jz_offset;
+    CPU.dec[0x61] = &disasm_ajmp_offset;
+    CPU.dec[0x62] = &disasm_xrl_mem_a;
+    CPU.dec[0x63] = &disasm_xrl_mem_imm;
+    CPU.dec[0x64] = &disasm_xrl_a_imm;
+    CPU.dec[0x65] = &disasm_xrl_a_mem;
+    CPU.dec[0x66] = &disasm_xrl_a_indir_rx;
+    CPU.dec[0x67] = &disasm_xrl_a_indir_rx;
 
-    aCPU->dec[0x70] = &disasm_jnz_offset;
-    aCPU->dec[0x71] = &disasm_acall_offset;
-    aCPU->dec[0x72] = &disasm_orl_c_bitaddr;
-    aCPU->dec[0x73] = &disasm_jmp_indir_a_dptr;
-    aCPU->dec[0x74] = &disasm_mov_a_imm;
-    aCPU->dec[0x75] = &disasm_mov_mem_imm;
-    aCPU->dec[0x76] = &disasm_mov_indir_rx_imm;
-    aCPU->dec[0x77] = &disasm_mov_indir_rx_imm;
+    CPU.dec[0x70] = &disasm_jnz_offset;
+    CPU.dec[0x71] = &disasm_acall_offset;
+    CPU.dec[0x72] = &disasm_orl_c_bitaddr;
+    CPU.dec[0x73] = &disasm_jmp_indir_a_dptr;
+    CPU.dec[0x74] = &disasm_mov_a_imm;
+    CPU.dec[0x75] = &disasm_mov_mem_imm;
+    CPU.dec[0x76] = &disasm_mov_indir_rx_imm;
+    CPU.dec[0x77] = &disasm_mov_indir_rx_imm;
 
-    aCPU->dec[0x80] = &disasm_sjmp_offset;
-    aCPU->dec[0x81] = &disasm_ajmp_offset;
-    aCPU->dec[0x82] = &disasm_anl_c_bitaddr;
-    aCPU->dec[0x83] = &disasm_movc_a_indir_a_pc;
-    aCPU->dec[0x84] = &disasm_div_ab;
-    aCPU->dec[0x85] = &disasm_mov_mem_mem;
-    aCPU->dec[0x86] = &disasm_mov_mem_indir_rx;
-    aCPU->dec[0x87] = &disasm_mov_mem_indir_rx;
+    CPU.dec[0x80] = &disasm_sjmp_offset;
+    CPU.dec[0x81] = &disasm_ajmp_offset;
+    CPU.dec[0x82] = &disasm_anl_c_bitaddr;
+    CPU.dec[0x83] = &disasm_movc_a_indir_a_pc;
+    CPU.dec[0x84] = &disasm_div_ab;
+    CPU.dec[0x85] = &disasm_mov_mem_mem;
+    CPU.dec[0x86] = &disasm_mov_mem_indir_rx;
+    CPU.dec[0x87] = &disasm_mov_mem_indir_rx;
 
-    aCPU->dec[0x90] = &disasm_mov_dptr_imm;
-    aCPU->dec[0x91] = &disasm_acall_offset;
-    aCPU->dec[0x92] = &disasm_mov_bitaddr_c;
-    aCPU->dec[0x93] = &disasm_movc_a_indir_a_dptr;
-    aCPU->dec[0x94] = &disasm_subb_a_imm;
-    aCPU->dec[0x95] = &disasm_subb_a_mem;
-    aCPU->dec[0x96] = &disasm_subb_a_indir_rx;
-    aCPU->dec[0x97] = &disasm_subb_a_indir_rx;
+    CPU.dec[0x90] = &disasm_mov_dptr_imm;
+    CPU.dec[0x91] = &disasm_acall_offset;
+    CPU.dec[0x92] = &disasm_mov_bitaddr_c;
+    CPU.dec[0x93] = &disasm_movc_a_indir_a_dptr;
+    CPU.dec[0x94] = &disasm_subb_a_imm;
+    CPU.dec[0x95] = &disasm_subb_a_mem;
+    CPU.dec[0x96] = &disasm_subb_a_indir_rx;
+    CPU.dec[0x97] = &disasm_subb_a_indir_rx;
 
-    aCPU->dec[0xa0] = &disasm_orl_c_compl_bitaddr;
-    aCPU->dec[0xa1] = &disasm_ajmp_offset;
-    aCPU->dec[0xa2] = &disasm_mov_c_bitaddr;
-    aCPU->dec[0xa3] = &disasm_inc_dptr;
-    aCPU->dec[0xa4] = &disasm_mul_ab;
-    aCPU->dec[0xa5] = &disasm_nop; // unused
-    aCPU->dec[0xa6] = &disasm_mov_indir_rx_mem;
-    aCPU->dec[0xa7] = &disasm_mov_indir_rx_mem;
+    CPU.dec[0xa0] = &disasm_orl_c_compl_bitaddr;
+    CPU.dec[0xa1] = &disasm_ajmp_offset;
+    CPU.dec[0xa2] = &disasm_mov_c_bitaddr;
+    CPU.dec[0xa3] = &disasm_inc_dptr;
+    CPU.dec[0xa4] = &disasm_mul_ab;
+    CPU.dec[0xa5] = &disasm_nop; // unused
+    CPU.dec[0xa6] = &disasm_mov_indir_rx_mem;
+    CPU.dec[0xa7] = &disasm_mov_indir_rx_mem;
 
-    aCPU->dec[0xb0] = &disasm_anl_c_compl_bitaddr;
-    aCPU->dec[0xb1] = &disasm_acall_offset;
-    aCPU->dec[0xb2] = &disasm_cpl_bitaddr;
-    aCPU->dec[0xb3] = &disasm_cpl_c;
-    aCPU->dec[0xb4] = &disasm_cjne_a_imm_offset;
-    aCPU->dec[0xb5] = &disasm_cjne_a_mem_offset;
-    aCPU->dec[0xb6] = &disasm_cjne_indir_rx_imm_offset;
-    aCPU->dec[0xb7] = &disasm_cjne_indir_rx_imm_offset;
+    CPU.dec[0xb0] = &disasm_anl_c_compl_bitaddr;
+    CPU.dec[0xb1] = &disasm_acall_offset;
+    CPU.dec[0xb2] = &disasm_cpl_bitaddr;
+    CPU.dec[0xb3] = &disasm_cpl_c;
+    CPU.dec[0xb4] = &disasm_cjne_a_imm_offset;
+    CPU.dec[0xb5] = &disasm_cjne_a_mem_offset;
+    CPU.dec[0xb6] = &disasm_cjne_indir_rx_imm_offset;
+    CPU.dec[0xb7] = &disasm_cjne_indir_rx_imm_offset;
 
-    aCPU->dec[0xc0] = &disasm_push_mem;
-    aCPU->dec[0xc1] = &disasm_ajmp_offset;
-    aCPU->dec[0xc2] = &disasm_clr_bitaddr;
-    aCPU->dec[0xc3] = &disasm_clr_c;
-    aCPU->dec[0xc4] = &disasm_swap_a;
-    aCPU->dec[0xc5] = &disasm_xch_a_mem;
-    aCPU->dec[0xc6] = &disasm_xch_a_indir_rx;
-    aCPU->dec[0xc7] = &disasm_xch_a_indir_rx;
+    CPU.dec[0xc0] = &disasm_push_mem;
+    CPU.dec[0xc1] = &disasm_ajmp_offset;
+    CPU.dec[0xc2] = &disasm_clr_bitaddr;
+    CPU.dec[0xc3] = &disasm_clr_c;
+    CPU.dec[0xc4] = &disasm_swap_a;
+    CPU.dec[0xc5] = &disasm_xch_a_mem;
+    CPU.dec[0xc6] = &disasm_xch_a_indir_rx;
+    CPU.dec[0xc7] = &disasm_xch_a_indir_rx;
 
-    aCPU->dec[0xd0] = &disasm_pop_mem;
-    aCPU->dec[0xd1] = &disasm_acall_offset;
-    aCPU->dec[0xd2] = &disasm_setb_bitaddr;
-    aCPU->dec[0xd3] = &disasm_setb_c;
-    aCPU->dec[0xd4] = &disasm_da_a;
-    aCPU->dec[0xd5] = &disasm_djnz_mem_offset;
-    aCPU->dec[0xd6] = &disasm_xchd_a_indir_rx;
-    aCPU->dec[0xd7] = &disasm_xchd_a_indir_rx;
+    CPU.dec[0xd0] = &disasm_pop_mem;
+    CPU.dec[0xd1] = &disasm_acall_offset;
+    CPU.dec[0xd2] = &disasm_setb_bitaddr;
+    CPU.dec[0xd3] = &disasm_setb_c;
+    CPU.dec[0xd4] = &disasm_da_a;
+    CPU.dec[0xd5] = &disasm_djnz_mem_offset;
+    CPU.dec[0xd6] = &disasm_xchd_a_indir_rx;
+    CPU.dec[0xd7] = &disasm_xchd_a_indir_rx;
 
-    aCPU->dec[0xe0] = &disasm_movx_a_indir_dptr;
-    aCPU->dec[0xe1] = &disasm_ajmp_offset;
-    aCPU->dec[0xe2] = &disasm_movx_a_indir_rx;
-    aCPU->dec[0xe3] = &disasm_movx_a_indir_rx;
-    aCPU->dec[0xe4] = &disasm_clr_a;
-    aCPU->dec[0xe5] = &disasm_mov_a_mem;
-    aCPU->dec[0xe6] = &disasm_mov_a_indir_rx;
-    aCPU->dec[0xe7] = &disasm_mov_a_indir_rx;
+    CPU.dec[0xe0] = &disasm_movx_a_indir_dptr;
+    CPU.dec[0xe1] = &disasm_ajmp_offset;
+    CPU.dec[0xe2] = &disasm_movx_a_indir_rx;
+    CPU.dec[0xe3] = &disasm_movx_a_indir_rx;
+    CPU.dec[0xe4] = &disasm_clr_a;
+    CPU.dec[0xe5] = &disasm_mov_a_mem;
+    CPU.dec[0xe6] = &disasm_mov_a_indir_rx;
+    CPU.dec[0xe7] = &disasm_mov_a_indir_rx;
 
-    aCPU->dec[0xf0] = &disasm_movx_indir_dptr_a;
-    aCPU->dec[0xf1] = &disasm_acall_offset;
-    aCPU->dec[0xf2] = &disasm_movx_indir_rx_a;
-    aCPU->dec[0xf3] = &disasm_movx_indir_rx_a;
-    aCPU->dec[0xf4] = &disasm_cpl_a;
-    aCPU->dec[0xf5] = &disasm_mov_mem_a;
-    aCPU->dec[0xf6] = &disasm_mov_indir_rx_a;
-    aCPU->dec[0xf7] = &disasm_mov_indir_rx_a;
+    CPU.dec[0xf0] = &disasm_movx_indir_dptr_a;
+    CPU.dec[0xf1] = &disasm_acall_offset;
+    CPU.dec[0xf2] = &disasm_movx_indir_rx_a;
+    CPU.dec[0xf3] = &disasm_movx_indir_rx_a;
+    CPU.dec[0xf4] = &disasm_cpl_a;
+    CPU.dec[0xf5] = &disasm_mov_mem_a;
+    CPU.dec[0xf6] = &disasm_mov_indir_rx_a;
+    CPU.dec[0xf7] = &disasm_mov_indir_rx_a;
 }

--- a/emu8051.c
+++ b/emu8051.c
@@ -1,0 +1,3 @@
+#include "emu8051.h"
+
+struct em8051 CPU;

--- a/emu8051.h
+++ b/emu8051.h
@@ -31,32 +31,32 @@
 struct em8051;
 
 // Operation: returns number of ticks the operation should take
-typedef uint8_t (*em8051operation)(struct em8051 *aCPU);
+typedef uint8_t (*em8051operation)();
 
 // Decodes opcode at position, and fills the buffer with the assembler code. 
 // Returns how many bytes the opcode takes.
-typedef uint8_t (*em8051decoder)(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer);
+typedef uint8_t (*em8051decoder)(uint16_t aPosition, char *aBuffer);
 
 // Callback: some exceptional situation occurred. See EM8051_EXCEPTION enum, below
-typedef void (*em8051exception)(struct em8051 *aCPU, int aCode);
+typedef void (*em8051exception)(int aCode);
 
 // Callback: an SFR register is about to be read (not called for 'a' ops nor psw changes)
 // Default is to return the value in the SFR register. Ports may act differently.
-typedef uint8_t (*em8051sfrread)(struct em8051 *aCPU, uint8_t aRegister);
+typedef uint8_t (*em8051sfrread)(uint8_t aRegister);
 
 // Callback: an SFR register has changed (not called for 'a' ops)
 // Default is to do nothing
-typedef void (*em8051sfrwrite)(struct em8051 *aCPU, uint8_t aRegister);
+typedef void (*em8051sfrwrite)(uint8_t aRegister);
 
 // Callback: writing to external memory
 // Default is to update external memory
 // (can be used to control some peripherals)
-typedef void (*em8051xwrite)(struct em8051 *aCPU, uint16_t aAddress, uint8_t aValue);
+typedef void (*em8051xwrite)(uint16_t aAddress, uint8_t aValue);
 
 // Callback: reading from external memory
 // Default is to return the value in external memory 
 // (can be used to control some peripherals)
-typedef uint8_t (*em8051xread)(struct em8051 *aCPU, uint16_t aAddress);
+typedef uint8_t (*em8051xread)(uint16_t aAddress);
 
 
 struct em8051
@@ -92,28 +92,30 @@ struct em8051
     uint8_t serial_interrupt_trigger;
 };
 
+extern struct em8051 CPU;
+
 // set the emulator into reset state. Must be called before tick(), as
 // it also initializes the function pointers. aWipe tells whether to reset
 // all memory to zero.
-void reset(struct em8051 *aCPU, uint8_t aWipe);
+void reset(uint8_t aWipe);
 
 // run one emulator tick, or 12 hardware clock cycles.
 // returns 1 if a new operation was executed.
-uint8_t tick(struct em8051 *aCPU);
+uint8_t tick();
 
 // decode the next operation as character string.
 // buffer must be big enough (64 bytes is very safe). 
 // Returns length of opcode.
-uint8_t decode(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer);
+uint8_t decode(uint16_t aPosition, char *aBuffer);
 
 // Load an intel hex format object file. Returns negative for errors.
-int load_obj(struct em8051 *aCPU, char *aFilename);
+int load_obj(char *aFilename);
 
 // Alternate way to execute an opcode (switch-structure instead of function pointers)
-uint8_t do_op(struct em8051 *aCPU);
+uint8_t do_op();
 
 // Internal: Pushes a value into stack
-void push_to_stack(struct em8051 *aCPU, uint8_t aValue);
+void push_to_stack(uint8_t aValue);
 
 
 // SFR register locations

--- a/emulator.h
+++ b/emulator.h
@@ -81,43 +81,43 @@ extern int opt_input_outputlow;
 // emu.c
 extern int getTick();
 extern void setSpeed(int speed, int runmode);
-//extern uint8_t emu_sfrread(struct em8051 *aCPU, uint8_t aRegister);
-extern void refreshview(struct em8051 *aCPU);
-extern void change_view(struct em8051 *aCPU, int changeto);
+//extern uint8_t emu_sfrread(uint8_t aRegister);
+extern void refreshview();
+extern void change_view(int changeto);
 
 // popups.c
-extern void emu_help(struct em8051 *aCPU);
-extern int emu_reset(struct em8051 *aCPU);
-extern int emu_readvalue(struct em8051 *aCPU, const char *aPrompt, int aOldvalue, int aValueSize);
-extern int emu_readhz(struct em8051 *aCPU, const char *aPrompt, int aOldvalue);
-extern void emu_load(struct em8051 *aCPU);
-extern void emu_exception(struct em8051 *aCPU, int aCode);
-extern void emu_popup(struct em8051 *aCPU, char *aTitle, char *aMessage);
+extern void emu_help();
+extern int emu_reset();
+extern int emu_readvalue(const char *aPrompt, int aOldvalue, int aValueSize);
+extern int emu_readhz(const char *aPrompt, int aOldvalue);
+extern void emu_load();
+extern void emu_exception(int aCode);
+extern void emu_popup(char *aTitle, char *aMessage);
 
 // mainview.c
-extern void mainview_editor_keys(struct em8051 *aCPU, int ch);
-extern void build_main_view(struct em8051 *aCPU);
+extern void mainview_editor_keys(int ch);
+extern void build_main_view();
 extern void wipe_main_view();
-extern void mainview_update(struct em8051 *aCPU);
+extern void mainview_update();
 
 // logicboard.c
 extern void wipe_logicboard_view();
-extern void build_logicboard_view(struct em8051 *aCPU);
-extern void logicboard_editor_keys(struct em8051 *aCPU, int ch);
-extern void logicboard_update(struct em8051 *aCPU);
-extern void logicboard_tick(struct em8051 *aCPU);
+extern void build_logicboard_view();
+extern void logicboard_editor_keys(int ch);
+extern void logicboard_update();
+extern void logicboard_tick();
 
 // memeditor.c
 extern void wipe_memeditor_view();
-extern void build_memeditor_view(struct em8051 *aCPU);
-extern void memeditor_editor_keys(struct em8051 *aCPU, int ch);
-extern void memeditor_update(struct em8051 *aCPU);
+extern void build_memeditor_view();
+extern void memeditor_editor_keys(int ch);
+extern void memeditor_update();
 
 // options.c
 extern void wipe_options_view();
-extern void build_options_view(struct em8051 *aCPU);
-extern void options_editor_keys(struct em8051 *aCPU, int ch);
-extern void options_update(struct em8051 *aCPU);
+extern void build_options_view();
+extern void options_editor_keys(int ch);
+extern void options_update();
 
 
 

--- a/logicboard.c
+++ b/logicboard.c
@@ -66,7 +66,7 @@ static void closeaudio(void)
     fclose(audioout);
 }
 
-void logicboard_tick(struct em8051 *aCPU)
+void logicboard_tick()
 {
     int i;
     if (logicmode == 2)
@@ -74,25 +74,25 @@ void logicboard_tick(struct em8051 *aCPU)
         for (i = 0; i < 4; i++)
         {
             int clockmask = 2 << (i * 2);
-            if ((oldports[0] & clockmask) == 0 && (aCPU->mSFR[REG_P0] & clockmask))
+            if ((oldports[0] & clockmask) == 0 && (CPU.mSFR[REG_P0] & clockmask))
             {
                 shiftregisters[i] <<= 1;
-                shiftregisters[i] |= (aCPU->mSFR[REG_P0] & (clockmask >> 1)) != 0;
+                shiftregisters[i] |= (CPU.mSFR[REG_P0] & (clockmask >> 1)) != 0;
             }
-            if ((oldports[1] & clockmask) == 0 && (aCPU->mSFR[REG_P1] & clockmask))
+            if ((oldports[1] & clockmask) == 0 && (CPU.mSFR[REG_P1] & clockmask))
             {
                 shiftregisters[i + 4] <<= 1;
-                shiftregisters[i + 4] |= (aCPU->mSFR[REG_P1] & (clockmask >> 1)) != 0;
+                shiftregisters[i + 4] |= (CPU.mSFR[REG_P1] & (clockmask >> 1)) != 0;
             }
-            if ((oldports[2] & clockmask) == 0 && (aCPU->mSFR[REG_P2] & clockmask))
+            if ((oldports[2] & clockmask) == 0 && (CPU.mSFR[REG_P2] & clockmask))
             {
                 shiftregisters[i + 8] <<= 1;
-                shiftregisters[i + 8] |= (aCPU->mSFR[REG_P2] & (clockmask >> 1)) != 0;
+                shiftregisters[i + 8] |= (CPU.mSFR[REG_P2] & (clockmask >> 1)) != 0;
             }
-            if ((oldports[3] & clockmask) == 0 && (aCPU->mSFR[REG_P3] & clockmask))
+            if ((oldports[3] & clockmask) == 0 && (CPU.mSFR[REG_P3] & clockmask))
             {
                 shiftregisters[i + 12] <<= 1;
-                shiftregisters[i + 12] |= (aCPU->mSFR[REG_P3] & (clockmask >> 1)) != 0;
+                shiftregisters[i + 12] |= (CPU.mSFR[REG_P3] & (clockmask >> 1)) != 0;
             }
         }
     }
@@ -104,15 +104,15 @@ void logicboard_tick(struct em8051 *aCPU)
 		if (chardisplaybusy > 0)
 			chardisplaybusy--;
 
-		if (((aCPU->mSFR[REG_P3] & 0x20) == 0x20) && 
+		if (((CPU.mSFR[REG_P3] & 0x20) == 0x20) &&
 			 ((oldports[3] & 0x80) == 0) &&
-			 ((aCPU->mSFR[REG_P3] & 0x80) != 0)) 
+			 ((CPU.mSFR[REG_P3] & 0x80) != 0))
 		{
 			// Read op
 			// - E level rises from low to high on read ops			
 
 
-			if (aCPU->mSFR[REG_P3] & 0x40)
+			if (CPU.mSFR[REG_P3] & 0x40)
 			{   // P3.6
 				// memory IO mode
 
@@ -168,33 +168,33 @@ void logicboard_tick(struct em8051 *aCPU)
 			}
 		}
 
-		if (((aCPU->mSFR[REG_P3] & 0x20) != 0x20) && 
+		if (((CPU.mSFR[REG_P3] & 0x20) != 0x20) &&
 			 ((oldports[3] & 0x80) != 0) &&
-			 ((aCPU->mSFR[REG_P3] & 0x80) == 0))
+			 ((CPU.mSFR[REG_P3] & 0x80) == 0))
 		{	// P3.7
 			// Write op
 			// - E level drops from high to low on write ops
 			
 			if (chardisplay4bmode == 0)
 			{
-				chardisplaydata = aCPU->mSFR[REG_P1];
+				chardisplaydata = CPU.mSFR[REG_P1];
 			}
 			else
 			{
 				if (!chardisplaytick)
 				{
-					chardisplaydata = (chardisplaydata & 0xf) | (aCPU->mSFR[REG_P1] & 0xf0);
+					chardisplaydata = (chardisplaydata & 0xf) | (CPU.mSFR[REG_P1] & 0xf0);
 				}
 				else
 				{
-					chardisplaydata = (chardisplaydata & 0xf0) | ((aCPU->mSFR[REG_P1] & 0xf0) >> 4);
+					chardisplaydata = (chardisplaydata & 0xf0) | ((CPU.mSFR[REG_P1] & 0xf0) >> 4);
 				}
 				chardisplaytick = !chardisplaytick;
 			}
 
 			if (!chardisplaytick || !chardisplay4bmode)
 			{
-				if (aCPU->mSFR[REG_P3] & 0x40)
+				if (CPU.mSFR[REG_P3] & 0x40)
 				{ // P3.6
 					if (!chardisplaybusy)
 					{
@@ -413,22 +413,22 @@ void logicboard_tick(struct em8051 *aCPU)
         audiotick++;
         if (audiotick > opt_clock_hz / (44100 * 12))
         {
-            fputc(aCPU->mSFR[REG_P3] & 0x80, audioout);
+            fputc(CPU.mSFR[REG_P3] & 0x80, audioout);
             audiotick -= opt_clock_hz / (44100 * 12);
         }
     }
-    oldports[0] = aCPU->mSFR[REG_P0];
-    oldports[1] = aCPU->mSFR[REG_P1];
-    oldports[2] = aCPU->mSFR[REG_P2];
-    oldports[3] = aCPU->mSFR[REG_P3];
+    oldports[0] = CPU.mSFR[REG_P0];
+    oldports[1] = CPU.mSFR[REG_P1];
+    oldports[2] = CPU.mSFR[REG_P2];
+    oldports[3] = CPU.mSFR[REG_P3];
 }
 
-static void logicboard_render_7segs(struct em8051 *aCPU)
+static void logicboard_render_7segs()
 {
-    int input1 = aCPU->mSFR[REG_P0];
-    int input2 = aCPU->mSFR[REG_P1];
-    int input3 = aCPU->mSFR[REG_P2];
-    int input4 = aCPU->mSFR[REG_P3];
+    int input1 = CPU.mSFR[REG_P0];
+    int input2 = CPU.mSFR[REG_P1];
+    int input3 = CPU.mSFR[REG_P2];
+    int input4 = CPU.mSFR[REG_P3];
     mvprintw(2, 40, " %c   %c   %c   %c ", " -"[(input4 >> 0)&1], " -"[(input3 >> 0)&1], " -"[(input2 >> 0)&1], " -"[(input1 >> 0)&1]);
     mvprintw(3, 40, "%c %c %c %c %c %c %c %c", " |"[(input4 >> 5)&1], " |"[(input4 >> 1)&1], " |"[(input3 >> 5)&1], " |"[(input3 >> 1)&1], " |"[(input2 >> 5)&1], " |"[(input2 >> 1)&1], " |"[(input1 >> 5)&1], " |"[(input1 >> 1)&1]);
     mvprintw(4, 40, " %c   %c   %c   %c ", " -"[(input4 >> 6)&1], " -"[(input3 >> 6)&1], " -"[(input2 >> 6)&1], " -"[(input1 >> 6)&1]);
@@ -533,14 +533,14 @@ void wipe_logicboard_view()
     logicboard_leavemode();
 }
 
-void build_logicboard_view(struct em8051 *aCPU)
+void build_logicboard_view()
 {
     erase();
     logicboard_entermode();
 }
 
 
-void logicboard_editor_keys(struct em8051 *aCPU, int ch)
+void logicboard_editor_keys(int ch)
 {
     int xorvalue = -1;
     switch (ch)
@@ -616,7 +616,7 @@ void logicboard_editor_keys(struct em8051 *aCPU, int ch)
     }
 }
 
-void logicboard_update(struct em8051 *aCPU)
+void logicboard_update()
 {
     char ledstate[]="_*";
     char swstate[]="01";
@@ -624,7 +624,7 @@ void logicboard_update(struct em8051 *aCPU)
     mvprintw( 1, 1, "Logic board view");
 
     mvprintw( 3, 5, "1 2 3 4 5 6 7 8");
-    data = aCPU->mSFR[REG_P0];
+    data = CPU.mSFR[REG_P0];
     mvprintw( 4, 2, "P0 %c %c %c %c %c %c %c %c",
         ledstate[(data>>7)&1],
         ledstate[(data>>6)&1],
@@ -646,7 +646,7 @@ void logicboard_update(struct em8051 *aCPU)
         swstate[(data>>1)&1],
         swstate[(data>>0)&1]);
 
-    data = aCPU->mSFR[REG_P1];
+    data = CPU.mSFR[REG_P1];
     mvprintw( 7, 2, "P1 %c %c %c %c %c %c %c %c",
         ledstate[(data>>7)&1],
         ledstate[(data>>6)&1],
@@ -668,7 +668,7 @@ void logicboard_update(struct em8051 *aCPU)
         swstate[(data>>1)&1],
         swstate[(data>>0)&1]);
 
-    data = aCPU->mSFR[REG_P2];
+    data = CPU.mSFR[REG_P2];
     mvprintw(10, 2, "P2 %c %c %c %c %c %c %c %c",
         ledstate[(data>>7)&1],
         ledstate[(data>>6)&1],
@@ -690,7 +690,7 @@ void logicboard_update(struct em8051 *aCPU)
         swstate[(data>>1)&1],
         swstate[(data>>0)&1]);
 
-    data = aCPU->mSFR[REG_P3];
+    data = CPU.mSFR[REG_P3];
     mvprintw(13, 2, "P3 %c %c %c %c %c %c %c %c",
         ledstate[(data>>7)&1],
         ledstate[(data>>6)&1],
@@ -740,7 +740,7 @@ void logicboard_update(struct em8051 *aCPU)
     switch (logicmode)
     {
     case 1:
-        logicboard_render_7segs(aCPU);
+        logicboard_render_7segs();
         break;
     case 2:
         logicboard_render_registers();

--- a/mainview.c
+++ b/mainview.c
@@ -121,7 +121,7 @@ void wipe_main_view()
     delwin(miscview);
 }
 
-void build_main_view(struct em8051 *aCPU)
+void build_main_view()
 {
     erase();
 
@@ -197,85 +197,85 @@ void build_main_view(struct em8051 *aCPU)
 
     lastclock = icount - 8;
 
-    memarea = aCPU->mLowerData;
+    memarea = CPU.mLowerData;
 
 }
 
-int getregoutput(struct em8051 *aCPU, int pos)
+int getregoutput(int pos)
 {
-    int rx = 8 * ((aCPU->mSFR[REG_PSW] & (PSWMASK_RS0|PSWMASK_RS1))>>PSW_RS0);
+    int rx = 8 * ((CPU.mSFR[REG_PSW] & (PSWMASK_RS0|PSWMASK_RS1))>>PSW_RS0);
     switch (pos)
     {
     case 0:
-        return aCPU->mSFR[REG_ACC];
+        return CPU.mSFR[REG_ACC];
     case 1:
-        return aCPU->mLowerData[rx + 0];
+        return CPU.mLowerData[rx + 0];
     case 2:
-        return aCPU->mLowerData[rx + 1];
+        return CPU.mLowerData[rx + 1];
     case 3:
-        return aCPU->mLowerData[rx + 2];
+        return CPU.mLowerData[rx + 2];
     case 4:
-        return aCPU->mLowerData[rx + 3];
+        return CPU.mLowerData[rx + 3];
     case 5:
-        return aCPU->mLowerData[rx + 4];
+        return CPU.mLowerData[rx + 4];
     case 6:
-        return aCPU->mLowerData[rx + 5];
+        return CPU.mLowerData[rx + 5];
     case 7:
-        return aCPU->mLowerData[rx + 6];
+        return CPU.mLowerData[rx + 6];
     case 8:
-        return aCPU->mLowerData[rx + 7];
+        return CPU.mLowerData[rx + 7];
     case 9:
-        return aCPU->mSFR[REG_B];
+        return CPU.mSFR[REG_B];
     case 10:
-        return aCPU->mSFR[REG_DPH] << 8 | aCPU->mSFR[REG_DPL];
+        return CPU.mSFR[REG_DPH] << 8 | CPU.mSFR[REG_DPL];
     }
     return 0;
 }
 
-void setregoutput(struct em8051 *aCPU, int pos, int val)
+void setregoutput(int pos, int val)
 {
-    int rx = 8 * ((aCPU->mSFR[REG_PSW] & (PSWMASK_RS0|PSWMASK_RS1))>>PSW_RS0);
+    int rx = 8 * ((CPU.mSFR[REG_PSW] & (PSWMASK_RS0|PSWMASK_RS1))>>PSW_RS0);
     switch (pos)
     {
     case 0:
-        aCPU->mSFR[REG_ACC] = val;
+        CPU.mSFR[REG_ACC] = val;
         break;
     case 1:
-        aCPU->mLowerData[rx + 0] = val;
+        CPU.mLowerData[rx + 0] = val;
         break;
     case 2:
-        aCPU->mLowerData[rx + 1] = val;
+        CPU.mLowerData[rx + 1] = val;
         break;
     case 3:
-        aCPU->mLowerData[rx + 2] = val;
+        CPU.mLowerData[rx + 2] = val;
         break;
     case 4:
-        aCPU->mLowerData[rx + 3] = val;
+        CPU.mLowerData[rx + 3] = val;
         break;
     case 5:
-        aCPU->mLowerData[rx + 4] = val;
+        CPU.mLowerData[rx + 4] = val;
         break;
     case 6:
-        aCPU->mLowerData[rx + 5] = val;
+        CPU.mLowerData[rx + 5] = val;
         break;
     case 7:
-        aCPU->mLowerData[rx + 6] = val;
+        CPU.mLowerData[rx + 6] = val;
         break;
     case 8:
-        aCPU->mLowerData[rx + 7] = val;
+        CPU.mLowerData[rx + 7] = val;
         break;
     case 9:
-        aCPU->mSFR[REG_B] = val;
+        CPU.mSFR[REG_B] = val;
         break;
     case 10:
-        aCPU->mSFR[REG_DPH] = (val >> 8) & 0xff;
-        aCPU->mSFR[REG_DPL] = val & 0xff;
+        CPU.mSFR[REG_DPH] = (val >> 8) & 0xff;
+        CPU.mSFR[REG_DPL] = val & 0xff;
         break;
     }
 }
 
 
-void mainview_editor_keys(struct em8051 *aCPU, int ch)
+void mainview_editor_keys(int ch)
 {
     int insert_value = -1;
     int maxmem;
@@ -293,28 +293,28 @@ void mainview_editor_keys(struct em8051 *aCPU, int ch)
         memcursorpos = 0;
         memoffset = 0;
         memmode++;
-        if (memmode == 1 && aCPU->mUpperData == NULL) 
+        if (memmode == 1 && CPU.mUpperData == NULL)
             memmode++;
-        if (memmode == 3 && aCPU->mExtData == NULL)
+        if (memmode == 3 && CPU.mExtData == NULL)
             memmode++;
         if (memmode == 5)
             memmode = 0;
         switch (memmode)
         {
         case 0:
-            memarea = aCPU->mLowerData;
+            memarea = CPU.mLowerData;
             break;
         case 1:
-            memarea = aCPU->mUpperData;
+            memarea = CPU.mUpperData;
             break;
         case 2:
-            memarea = aCPU->mSFR;
+            memarea = CPU.mSFR;
             break;
         case 3:
-            memarea = aCPU->mExtData;
+            memarea = CPU.mExtData;
             break;
         case 4:
-            memarea = aCPU->mCodeMem;
+            memarea = CPU.mCodeMem;
             break;
         }
         mvwaddstr(rambox, 0, 4, memtypes[memmode]);
@@ -395,10 +395,10 @@ void mainview_editor_keys(struct em8051 *aCPU, int ch)
         maxmem = 128;
         break;
     case 3:
-        maxmem = aCPU->mExtDataMaxIdx+1;
+        maxmem = CPU.mExtDataMaxIdx+1;
         break;
     case 4:
-        maxmem = aCPU->mCodeMemMaxIdx+1;
+        maxmem = CPU.mCodeMemMaxIdx+1;
         break;
     }
 
@@ -416,15 +416,15 @@ void mainview_editor_keys(struct em8051 *aCPU, int ch)
         {
             if (cursorpos / 2 >= 10)
             {
-                int oldvalue = getregoutput(aCPU, 10);
-                setregoutput(aCPU, 10, (oldvalue & ~(0xf000 >> (4 * (cursorpos & 3)))) | (insert_value << (4 * (3 - (cursorpos & 3)))));
+                int oldvalue = getregoutput(10);
+                setregoutput(10, (oldvalue & ~(0xf000 >> (4 * (cursorpos & 3)))) | (insert_value << (4 * (3 - (cursorpos & 3)))));
             }
             else
             {
                 if (cursorpos & 1)
-                    setregoutput(aCPU, cursorpos / 2, (getregoutput(aCPU, cursorpos / 2) & 0xf0) | insert_value);
+                    setregoutput(cursorpos / 2, (getregoutput(cursorpos / 2) & 0xf0) | insert_value);
                 else
-                    setregoutput(aCPU, cursorpos / 2, (getregoutput(aCPU, cursorpos / 2) & 0x0f) | (insert_value << 4));
+                    setregoutput(cursorpos / 2, (getregoutput(cursorpos / 2) & 0x0f) | (insert_value << 4));
             }
             cursorpos++;
             if (cursorpos > 23)
@@ -461,30 +461,30 @@ void mainview_editor_keys(struct em8051 *aCPU, int ch)
 }
 
 
-void refresh_regoutput(struct em8051 *aCPU, int cursor)
+void refresh_regoutput(int cursor)
 {
-    int rx = 8 * ((aCPU->mSFR[REG_PSW] & (PSWMASK_RS0|PSWMASK_RS1))>>PSW_RS0);
+    int rx = 8 * ((CPU.mSFR[REG_PSW] & (PSWMASK_RS0|PSWMASK_RS1))>>PSW_RS0);
     
     mvwprintw(regoutput, LINES-19, 0, "%02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %04X",
-        aCPU->mSFR[REG_ACC],
-        aCPU->mLowerData[0 + rx],
-        aCPU->mLowerData[1 + rx],
-        aCPU->mLowerData[2 + rx],
-        aCPU->mLowerData[3 + rx],
-        aCPU->mLowerData[4 + rx],
-        aCPU->mLowerData[5 + rx],
-        aCPU->mLowerData[6 + rx],
-        aCPU->mLowerData[7 + rx],
-        aCPU->mSFR[REG_B],
-        (aCPU->mSFR[REG_DPH]<<8)|aCPU->mSFR[REG_DPL]);
+        CPU.mSFR[REG_ACC],
+        CPU.mLowerData[0 + rx],
+        CPU.mLowerData[1 + rx],
+        CPU.mLowerData[2 + rx],
+        CPU.mLowerData[3 + rx],
+        CPU.mLowerData[4 + rx],
+        CPU.mLowerData[5 + rx],
+        CPU.mLowerData[6 + rx],
+        CPU.mLowerData[7 + rx],
+        CPU.mSFR[REG_B],
+        (CPU.mSFR[REG_DPH]<<8)|CPU.mSFR[REG_DPL]);
 
     if (focus == 1 && cursor)
     {   
-        int bytevalue = getregoutput(aCPU, cursorpos / 2);
+        int bytevalue = getregoutput(cursorpos / 2);
         if (cursorpos / 2 == 10)
-            bytevalue = getregoutput(aCPU, 10) >> 8;
+            bytevalue = getregoutput(10) >> 8;
         if (cursorpos / 2 == 11)
-            bytevalue = getregoutput(aCPU, 10) & 0xff;
+            bytevalue = getregoutput(10) & 0xff;
         wattron(regoutput, A_REVERSE);
         wmove(regoutput, LINES-19, (cursorpos / 2) * 3 + (cursorpos & 1) - (cursorpos / 22));
         wprintw(regoutput,"%X", (bytevalue >> (4 * (!(cursorpos & 1)))) & 0xf);
@@ -492,7 +492,7 @@ void refresh_regoutput(struct em8051 *aCPU, int cursor)
     }
 }
 
-void mainview_update(struct em8051 *aCPU)
+void mainview_update()
 {
     int bytevalue = 0;
     int i;
@@ -523,12 +523,12 @@ void mainview_update(struct em8051 *aCPU)
             hoffs = (hline * (128 + 64 + sizeof(int)));
 
             memcpy(&old_pc, history + hoffs + 128 + 64, sizeof(int));
-            opcode_bytes = decode(aCPU, old_pc, assembly);
+            opcode_bytes = decode(old_pc, assembly);
             stringpos = 0;
             stringpos += sprintf(temp + stringpos,"\n%04X  ", old_pc & 0xffff);
             
             for (i = 0; i < opcode_bytes; i++)
-                stringpos += sprintf(temp + stringpos,"%02X ", aCPU->mCodeMem[(old_pc + i) & (aCPU->mCodeMemMaxIdx)]);
+                stringpos += sprintf(temp + stringpos,"%02X ", CPU.mCodeMem[(old_pc + i) & (CPU.mCodeMemMaxIdx)]);
             
             for (i = opcode_bytes; i < 3; i++)
                 stringpos += sprintf(temp + stringpos,"   ");
@@ -552,7 +552,7 @@ void mainview_update(struct em8051 *aCPU)
                 history[hoffs + REG_B],
                 (history[hoffs + REG_DPH]<<8)|history[hoffs + REG_DPL]);
             if (focus == 1)
-                refresh_regoutput(aCPU, 0);
+                refresh_regoutput(0);
             wprintw(regoutput,"%s",temp);
 
             sprintf(temp, "\n%d %d %d %d %d %d %d %d",
@@ -598,14 +598,14 @@ void mainview_update(struct em8051 *aCPU)
     wprintw(miscview, "HW     : Super8051 @%0.1fMHz\n", opt_clock_hz / (1000*1000.0f));
 
     // convert the buffer to printable chars
-    char serial_buffer[sizeof(aCPU->serial_out)];
+    char serial_buffer[sizeof(CPU.serial_out)];
     for (size_t i = 0; i < sizeof(serial_buffer); i ++) {
-        char c = aCPU->serial_out[i];
+        char c = CPU.serial_out[i];
         serial_buffer[i] = isprint(c) ? c : '_';
     }
     {
-        char c = aCPU->mSFR[REG_SBUF]; c = isprint(c) ? c : '_';
-        wprintw(miscview, "S%d %c=%02x: %18s", aCPU->serial_out_remaining_bits, c, aCPU->mSFR[REG_SBUF], serial_buffer);
+        char c = CPU.mSFR[REG_SBUF]; c = isprint(c) ? c : '_';
+        wprintw(miscview, "S%d %c=%02x: %18s", CPU.serial_out_remaining_bits, c, CPU.mSFR[REG_SBUF], serial_buffer);
     }
 
     werase(ramview);
@@ -626,7 +626,7 @@ void mainview_update(struct em8051 *aCPU)
         wattroff(ramview, A_REVERSE);
     }
 
-    refresh_regoutput(aCPU, 1);
+    refresh_regoutput(1);
 
     if (focus == 0)
     {
@@ -645,11 +645,11 @@ void mainview_update(struct em8051 *aCPU)
 
     if (focus == 1)
     {
-        bytevalue = getregoutput(aCPU, cursorpos / 2);
+        bytevalue = getregoutput(cursorpos / 2);
         if (cursorpos / 2 == 10)
-            bytevalue = (getregoutput(aCPU, 10) >> 8) & 0xff;
+            bytevalue = (getregoutput(10) >> 8) & 0xff;
         if (cursorpos / 2 == 11)
-            bytevalue = getregoutput(aCPU, 10) & 0xff;
+            bytevalue = getregoutput(10) & 0xff;
 
         mvwprintw(miscview, 0,0,"%s: %d %d %d %d %d %d %d %d", 
                 regtypes[cursorpos / 2],
@@ -665,11 +665,11 @@ void mainview_update(struct em8051 *aCPU)
 
     for (i = 0; i < 14; i++)
     {
-		int offset = (i + aCPU->mSFR[REG_SP]-7)&0xff;
+		int offset = (i + CPU.mSFR[REG_SP]-7)&0xff;
 		if (offset < 0x80)
-			wprintw(stackview," %02X\n", aCPU->mLowerData[offset]);
+			wprintw(stackview," %02X\n", CPU.mLowerData[offset]);
 		else
-			wprintw(stackview," %02X\n", aCPU->mUpperData[offset - 0x80]);
+			wprintw(stackview," %02X\n", CPU.mUpperData[offset - 0x80]);
     }
 
     if (speed != 0 || runmode == 0)

--- a/memeditor.c
+++ b/memeditor.c
@@ -57,7 +57,7 @@ void wipe_memeditor_view()
     }
 }
 
-void build_memeditor_view(struct em8051 *aCPU)
+void build_memeditor_view()
 {
     erase();
     
@@ -67,7 +67,7 @@ void build_memeditor_view(struct em8051 *aCPU)
     mvwaddstr(eds[0].box, 0, 2, "Lower");
     eds[0].view = subwin(eds[0].box, eds[0].lines - 2, 38, 1, 1);
     eds[0].maxmem = 128;
-    eds[0].memarea = aCPU->mLowerData;
+    eds[0].memarea = CPU.mLowerData;
     eds[0].memviewoffset = 0;
 
     eds[1].lines = (LINES / 3);
@@ -75,11 +75,11 @@ void build_memeditor_view(struct em8051 *aCPU)
     box(eds[1].box,ACS_VLINE,ACS_HLINE);
     mvwaddstr(eds[1].box, 0, 2, "Upper");
     eds[1].view = subwin(eds[1].box, eds[1].lines - 2, 38, eds[0].lines + 1, 1);
-    if (aCPU->mUpperData)
+    if (CPU.mUpperData)
         eds[1].maxmem = 128;
     else
         eds[1].maxmem = 0;
-    eds[1].memarea = aCPU->mUpperData;
+    eds[1].memarea = CPU.mUpperData;
     eds[1].memviewoffset = 128;
 
     eds[2].lines = LINES - (eds[0].lines + eds[1].lines);
@@ -88,7 +88,7 @@ void build_memeditor_view(struct em8051 *aCPU)
     mvwaddstr(eds[2].box, 0, 2, "SFR");
     eds[2].view = subwin(eds[2].box, eds[2].lines - 2, 38, eds[0].lines + eds[1].lines + 1, 1);
     eds[2].maxmem = 128;
-    eds[2].memarea = aCPU->mSFR;
+    eds[2].memarea = CPU.mSFR;
     eds[2].memviewoffset = 128;
 
     eds[3].lines = LINES / 2;
@@ -96,8 +96,8 @@ void build_memeditor_view(struct em8051 *aCPU)
     box(eds[3].box,ACS_VLINE,ACS_HLINE);
     mvwaddstr(eds[3].box, 0, 2, "External");
     eds[3].view = subwin(eds[3].box, eds[3].lines - 2, 38, 1, 41);    
-    eds[3].maxmem = aCPU->mExtDataMaxIdx+1;
-    eds[3].memarea = aCPU->mExtData;
+    eds[3].maxmem = CPU.mExtDataMaxIdx+1;
+    eds[3].memarea = CPU.mExtData;
     eds[3].memviewoffset = 0;
 
     eds[4].lines = LINES / 2;
@@ -105,8 +105,8 @@ void build_memeditor_view(struct em8051 *aCPU)
     box(eds[4].box,ACS_VLINE,ACS_HLINE);
     mvwaddstr(eds[4].box, 0, 2, "ROM");
     eds[4].view = subwin(eds[4].box, eds[4].lines - 2, 38, eds[3].lines + 1, 41);
-    eds[4].maxmem = aCPU->mCodeMemMaxIdx+1;
-    eds[4].memarea = aCPU->mCodeMem;     
+    eds[4].maxmem = CPU.mCodeMemMaxIdx+1;
+    eds[4].memarea = CPU.mCodeMem;
     eds[4].memviewoffset = 0;
 
     // TODO: make sure cursorpos / memoffset are within legal values,
@@ -127,7 +127,7 @@ void build_memeditor_view(struct em8051 *aCPU)
     refresh();
 }
 
-void memeditor_editor_keys(struct em8051 *aCPU, int ch)
+void memeditor_editor_keys(int ch)
 {
     int insert_value = -1;
     switch(ch)
@@ -135,9 +135,9 @@ void memeditor_editor_keys(struct em8051 *aCPU, int ch)
     case KEY_NEXT:
     case '\t':
         focus++;
-        if (focus == 1 && aCPU->mUpperData == NULL) 
+        if (focus == 1 && CPU.mUpperData == NULL)
             focus++;
-        if (focus == 3 && aCPU->mExtData == NULL)
+        if (focus == 3 && CPU.mExtData == NULL)
             focus++;
         if (focus == 5)
             focus = 0;
@@ -237,7 +237,7 @@ void memeditor_editor_keys(struct em8051 *aCPU, int ch)
 
 #define MASK_PRINTABLES(x) (((x) > 31)?(((x) < 127)?(x):'.'):'.')
 
-void memeditor_update(struct em8051 *aCPU)
+void memeditor_update()
 {
     int i, j, bytevalue;
     for (i = 0; i < 5; i++)

--- a/opcodes.c
+++ b/opcodes.c
@@ -32,87 +32,87 @@
 #include "emu8051.h"
 
 #define BAD_VALUE 0x77
-#define PSW aCPU->mSFR[REG_PSW]
-#define ACC aCPU->mSFR[REG_ACC]
-#define PC aCPU->mPC
-#define CODEMEM(x) aCPU->mCodeMem[(x)&(aCPU->mCodeMemMaxIdx)]
-#define EXTDATA(x) aCPU->mExtData[(x)&(aCPU->mExtDataMaxIdx)]
-#define UPRDATA(x) aCPU->mUpperData[(x) - 0x80]
+#define PSW CPU.mSFR[REG_PSW]
+#define ACC CPU.mSFR[REG_ACC]
+#define PC CPU.mPC
+#define CODEMEM(x) CPU.mCodeMem[(x)&(CPU.mCodeMemMaxIdx)]
+#define EXTDATA(x) CPU.mExtData[(x)&(CPU.mExtDataMaxIdx)]
+#define UPRDATA(x) CPU.mUpperData[(x) - 0x80]
 #define OPCODE CODEMEM(PC + 0)
 #define OPERAND1 CODEMEM(PC + 1)
 #define OPERAND2 CODEMEM(PC + 2)
-#define INDIR_RX_ADDRESS (aCPU->mLowerData[(OPCODE & 1) + 8 * ((PSW & (PSWMASK_RS0|PSWMASK_RS1))>>PSW_RS0)])
+#define INDIR_RX_ADDRESS (CPU.mLowerData[(OPCODE & 1) + 8 * ((PSW & (PSWMASK_RS0|PSWMASK_RS1))>>PSW_RS0)])
 #define RX_ADDRESS ((OPCODE & 7) + 8 * ((PSW & (PSWMASK_RS0|PSWMASK_RS1))>>PSW_RS0))
 #define CARRY ((PSW & PSWMASK_C) >> PSW_C)
 
-static uint8_t read_mem(struct em8051 *aCPU, uint8_t aAddress)
+static uint8_t read_mem(uint8_t aAddress)
 {
     if (aAddress > 0x7f)
     {
-        if (aCPU->sfrread[aAddress - 0x80])
-            return aCPU->sfrread[aAddress - 0x80](aCPU, aAddress);
+        if (CPU.sfrread[aAddress - 0x80])
+            return CPU.sfrread[aAddress - 0x80](aAddress);
         else
-            return aCPU->mSFR[aAddress - 0x80];
+            return CPU.mSFR[aAddress - 0x80];
     }
     else
     {
-        return aCPU->mLowerData[aAddress];
+        return CPU.mLowerData[aAddress];
     }
 }
 
-void push_to_stack(struct em8051 *aCPU, uint8_t aValue)
+void push_to_stack(uint8_t aValue)
 {
-    aCPU->mSFR[REG_SP]++;
-    if (aCPU->mSFR[REG_SP] > 0x7f)
+    CPU.mSFR[REG_SP]++;
+    if (CPU.mSFR[REG_SP] > 0x7f)
     {
-        if (aCPU->mUpperData)
+        if (CPU.mUpperData)
         {
-            UPRDATA(aCPU->mSFR[REG_SP]) = aValue;
+            UPRDATA(CPU.mSFR[REG_SP]) = aValue;
         }
         else
         {
-            if (aCPU->except)
-                aCPU->except(aCPU, EXCEPTION_STACK);
+            if (CPU.except)
+                CPU.except(EXCEPTION_STACK);
         }
     }
     else
     {
-        aCPU->mLowerData[aCPU->mSFR[REG_SP]] = aValue;
+        CPU.mLowerData[CPU.mSFR[REG_SP]] = aValue;
     }
-    if (aCPU->mSFR[REG_SP] == 0)
-        if (aCPU->except)
-            aCPU->except(aCPU, EXCEPTION_STACK);
+    if (CPU.mSFR[REG_SP] == 0)
+        if (CPU.except)
+            CPU.except(EXCEPTION_STACK);
 }
 
-static uint8_t pop_from_stack(struct em8051 *aCPU)
+static uint8_t pop_from_stack()
 {
     uint8_t value = BAD_VALUE;
-    if (aCPU->mSFR[REG_SP] > 0x7f)
+    if (CPU.mSFR[REG_SP] > 0x7f)
     {
-        if (aCPU->mUpperData)
+        if (CPU.mUpperData)
         {
-            value = UPRDATA(aCPU->mSFR[REG_SP]);
+            value = UPRDATA(CPU.mSFR[REG_SP]);
         }
         else
         {
-            if (aCPU->except)
-                aCPU->except(aCPU, EXCEPTION_STACK);
+            if (CPU.except)
+                CPU.except(EXCEPTION_STACK);
         }
     }
     else
     {
-        value = aCPU->mLowerData[aCPU->mSFR[REG_SP]];
+        value = CPU.mLowerData[CPU.mSFR[REG_SP]];
     }
-    aCPU->mSFR[REG_SP]--;
+    CPU.mSFR[REG_SP]--;
 
-    if (aCPU->mSFR[REG_SP] == 0xff)
-        if (aCPU->except)
-            aCPU->except(aCPU, EXCEPTION_STACK);
+    if (CPU.mSFR[REG_SP] == 0xff)
+        if (CPU.except)
+            CPU.except(EXCEPTION_STACK);
     return value;
 }
 
 
-static void add_solve_flags(struct em8051 * aCPU, uint8_t value1, uint8_t value2, uint8_t acc)
+static void add_solve_flags(uint8_t value1, uint8_t value2, uint8_t acc)
 {
     /* Carry: overflow from 7th bit to 8th bit */
     uint8_t carry = ((value1 & 255) + (value2 & 255) + acc) >> 8;
@@ -127,7 +127,7 @@ static void add_solve_flags(struct em8051 * aCPU, uint8_t value1, uint8_t value2
           (carry << PSW_C) | (auxcarry << PSW_AC) | (overflow << PSW_OV);
 }
 
-static void sub_solve_flags(struct em8051 * aCPU, uint8_t value1, uint8_t value2)
+static void sub_solve_flags(uint8_t value1, uint8_t value2)
 {
     uint8_t carry = (((value1 & 255) - (value2 & 255)) >> 8) & 1;
     uint8_t auxcarry = (((value1 & 7) - (value2 & 7)) >> 3) & 1;
@@ -137,7 +137,7 @@ static void sub_solve_flags(struct em8051 * aCPU, uint8_t value1, uint8_t value2
 }
 
 
-static uint8_t ajmp_offset(struct em8051 *aCPU)
+static uint8_t ajmp_offset()
 {
     uint16_t address = ( (PC + 2) & 0xf800 ) |
                   OPERAND1 | 
@@ -148,7 +148,7 @@ static uint8_t ajmp_offset(struct em8051 *aCPU)
     return 1;
 }
 
-static uint8_t ljmp_address(struct em8051 *aCPU)
+static uint8_t ljmp_address()
 {
     uint16_t address = (OPERAND1 << 8) | OPERAND2;
     PC = address;
@@ -157,56 +157,56 @@ static uint8_t ljmp_address(struct em8051 *aCPU)
 }
 
 
-static uint8_t rr_a(struct em8051 *aCPU)
+static uint8_t rr_a()
 {
     ACC = (ACC >> 1) | (ACC << 7);
     PC++;
     return 0;
 }
 
-static uint8_t inc_a(struct em8051 *aCPU)
+static uint8_t inc_a()
 {
     ACC++;
     PC++;
     return 0;
 }
 
-static uint8_t inc_mem(struct em8051 *aCPU)
+static uint8_t inc_mem()
 {
     uint8_t address = OPERAND1;
     if (address > 0x7f)
     {
-        aCPU->mSFR[address - 0x80]++;
-        if (aCPU->sfrwrite[address - 0x80])
-            aCPU->sfrwrite[address - 0x80](aCPU, address);
+        CPU.mSFR[address - 0x80]++;
+        if (CPU.sfrwrite[address - 0x80])
+            CPU.sfrwrite[address - 0x80](address);
     }
     else
     {
-        aCPU->mLowerData[address]++;
+        CPU.mLowerData[address]++;
     }
     PC += 2;
     return 0;
 }
 
-static uint8_t inc_indir_rx(struct em8051 *aCPU)
+static uint8_t inc_indir_rx()
 {    
     uint8_t address = INDIR_RX_ADDRESS;
     if (address > 0x7f)
     {
-        if (aCPU->mUpperData)
+        if (CPU.mUpperData)
         {
-            aCPU->mUpperData[address - 0x80]++;
+            CPU.mUpperData[address - 0x80]++;
         }
     }
     else
     {
-        aCPU->mLowerData[address]++;
+        CPU.mLowerData[address]++;
     }
     PC++;
     return 0;
 }
 
-static uint8_t jbc_bitaddr_offset(struct em8051 *aCPU)
+static uint8_t jbc_bitaddr_offset()
 {
     // "Note: when this instruction is used to test an output pin, the value used 
     // as the original data will be read from the output data latch, not the input pin"
@@ -217,14 +217,14 @@ static uint8_t jbc_bitaddr_offset(struct em8051 *aCPU)
         uint8_t bitmask = (1 << bit);
         uint8_t value;
         address &= 0xf8;        
-        value = aCPU->mSFR[address - 0x80];
+        value = CPU.mSFR[address - 0x80];
         
         if (value & bitmask)
         {
-            aCPU->mSFR[address - 0x80] &= ~bitmask;
+            CPU.mSFR[address - 0x80] &= ~bitmask;
             PC += (signed char)OPERAND2 + 3;
-            if (aCPU->sfrwrite[address - 0x80])
-                aCPU->sfrwrite[address - 0x80](aCPU, address);
+            if (CPU.sfrwrite[address - 0x80])
+                CPU.sfrwrite[address - 0x80](address);
         }
         else
         {
@@ -237,9 +237,9 @@ static uint8_t jbc_bitaddr_offset(struct em8051 *aCPU)
         uint8_t bitmask = (1 << bit);
         address >>= 3;
         address += 0x20;
-        if (aCPU->mLowerData[address] & bitmask)
+        if (CPU.mLowerData[address] & bitmask)
         {
-            aCPU->mLowerData[address] &= ~bitmask;
+            CPU.mLowerData[address] &= ~bitmask;
             PC += (signed char)OPERAND2 + 3;
         }
         else
@@ -250,25 +250,25 @@ static uint8_t jbc_bitaddr_offset(struct em8051 *aCPU)
     return 1;
 }
 
-static uint8_t acall_offset(struct em8051 *aCPU)
+static uint8_t acall_offset()
 {
     uint16_t address = ((PC + 2) & 0xf800) | OPERAND1 | ((OPCODE & 0xe0) << 3);
-    push_to_stack(aCPU, (PC + 2) & 0xff);
-    push_to_stack(aCPU, (PC + 2) >> 8);
+    push_to_stack((PC + 2) & 0xff);
+    push_to_stack((PC + 2) >> 8);
     PC = address;
     return 1;
 }
 
-static uint8_t lcall_address(struct em8051 *aCPU)
+static uint8_t lcall_address()
 {
-    push_to_stack(aCPU, (PC + 3) & 0xff);
-    push_to_stack(aCPU, (PC + 3) >> 8);
+    push_to_stack((PC + 3) & 0xff);
+    push_to_stack((PC + 3) >> 8);
     PC = (OPERAND1 << 8) |
          (OPERAND2 << 0);
     return 1;
 }
 
-static uint8_t rrc_a(struct em8051 *aCPU)
+static uint8_t rrc_a()
 {
     uint8_t c = (PSW & PSWMASK_C) >> PSW_C;
     uint8_t newc = ACC & 1;
@@ -278,50 +278,50 @@ static uint8_t rrc_a(struct em8051 *aCPU)
     return 0;
 }
 
-static uint8_t dec_a(struct em8051 *aCPU)
+static uint8_t dec_a()
 {
     ACC--;
     PC++;
     return 0;
 }
 
-static uint8_t dec_mem(struct em8051 *aCPU)
+static uint8_t dec_mem()
 {
     uint8_t address = OPERAND1;
     if (address > 0x7f)
     {
-        aCPU->mSFR[address - 0x80]--;
-        if (aCPU->sfrwrite[address - 0x80])
-            aCPU->sfrwrite[address - 0x80](aCPU, address);
+        CPU.mSFR[address - 0x80]--;
+        if (CPU.sfrwrite[address - 0x80])
+            CPU.sfrwrite[address - 0x80](address);
     }
     else
     {
-        aCPU->mLowerData[address]--;
+        CPU.mLowerData[address]--;
     }
     PC += 2;
     return 0;
 }
 
-static uint8_t dec_indir_rx(struct em8051 *aCPU)
+static uint8_t dec_indir_rx()
 {
     uint8_t address = INDIR_RX_ADDRESS;
     if (address > 0x7f)
     {
-        if (aCPU->mUpperData)
+        if (CPU.mUpperData)
         {
-            aCPU->mUpperData[address - 0x80]--;
+            CPU.mUpperData[address - 0x80]--;
         }
     }
     else
     {
-        aCPU->mLowerData[address]--;
+        CPU.mLowerData[address]--;
     }
     PC++;
     return 0;
 }
 
 
-static uint8_t jb_bitaddr_offset(struct em8051 *aCPU)
+static uint8_t jb_bitaddr_offset()
 {
     uint8_t address = OPERAND1;
     if (address > 0x7f)
@@ -330,10 +330,10 @@ static uint8_t jb_bitaddr_offset(struct em8051 *aCPU)
         uint8_t bitmask = (1 << bit);
         uint8_t value;
         address &= 0xf8;        
-        if (aCPU->sfrread[address - 0x80])
-            value = aCPU->sfrread[address - 0x80](aCPU, address);
+        if (CPU.sfrread[address - 0x80])
+            value = CPU.sfrread[address - 0x80](address);
         else
-            value = aCPU->mSFR[address - 0x80];
+            value = CPU.mSFR[address - 0x80];
         
         if (value & bitmask)
         {
@@ -350,7 +350,7 @@ static uint8_t jb_bitaddr_offset(struct em8051 *aCPU)
         uint8_t bitmask = (1 << bit);
         address >>= 3;
         address += 0x20;
-        if (aCPU->mLowerData[address] & bitmask)
+        if (CPU.mLowerData[address] & bitmask)
         {
             PC += (signed char)OPERAND2 + 3;
         }
@@ -362,62 +362,62 @@ static uint8_t jb_bitaddr_offset(struct em8051 *aCPU)
     return 1;
 }
 
-static uint8_t ret(struct em8051 *aCPU)
+static uint8_t ret()
 {
-    PC = pop_from_stack(aCPU) << 8;
-    PC |= pop_from_stack(aCPU);
+    PC = pop_from_stack() << 8;
+    PC |= pop_from_stack();
     return 1;
 }
 
-static uint8_t rl_a(struct em8051 *aCPU)
+static uint8_t rl_a()
 {
     ACC = (ACC << 1) | (ACC >> 7);
     PC++;
     return 0;
 }
 
-static uint8_t add_a_imm(struct em8051 *aCPU)
+static uint8_t add_a_imm()
 {
-    add_solve_flags(aCPU, ACC, OPERAND1, 0);
+    add_solve_flags(ACC, OPERAND1, 0);
     ACC += OPERAND1;
     PC += 2;
     return 0;
 }
 
-static uint8_t add_a_mem(struct em8051 *aCPU)
+static uint8_t add_a_mem()
 {
-    uint8_t value = read_mem(aCPU, OPERAND1);
-    add_solve_flags(aCPU, ACC, value, 0);
+    uint8_t value = read_mem(OPERAND1);
+    add_solve_flags(ACC, value, 0);
     ACC += value;
 	PC += 2;
     return 0;
 }
 
-static uint8_t add_a_indir_rx(struct em8051 *aCPU)
+static uint8_t add_a_indir_rx()
 {
     uint8_t address = INDIR_RX_ADDRESS;
     if (address > 0x7f)
     {
         uint8_t value = BAD_VALUE;
-        if (aCPU->mUpperData)
+        if (CPU.mUpperData)
         {
-            value = aCPU->mUpperData[address - 0x80];
+            value = CPU.mUpperData[address - 0x80];
         }
 
-        add_solve_flags(aCPU, ACC, value, 0);
+        add_solve_flags(ACC, value, 0);
         ACC += value;
     }
     else
     {
-        add_solve_flags(aCPU, ACC, aCPU->mLowerData[address], 0);
-        ACC += aCPU->mLowerData[address];
+        add_solve_flags(ACC, CPU.mLowerData[address], 0);
+        ACC += CPU.mLowerData[address];
     }
 
     PC++;
     return 0;
 }
 
-static uint8_t jnb_bitaddr_offset(struct em8051 *aCPU)
+static uint8_t jnb_bitaddr_offset()
 {
     uint8_t address = OPERAND1;
     if (address > 0x7f)
@@ -426,10 +426,10 @@ static uint8_t jnb_bitaddr_offset(struct em8051 *aCPU)
         uint8_t bitmask = (1 << bit);
         uint8_t value;
         address &= 0xf8;        
-        if (aCPU->sfrread[address - 0x80])
-            value = aCPU->sfrread[address - 0x80](aCPU, address);
+        if (CPU.sfrread[address - 0x80])
+            value = CPU.sfrread[address - 0x80](address);
         else
-            value = aCPU->mSFR[address - 0x80];
+            value = CPU.mSFR[address - 0x80];
         
         if (!(value & bitmask))
         {
@@ -446,7 +446,7 @@ static uint8_t jnb_bitaddr_offset(struct em8051 *aCPU)
         uint8_t bitmask = (1 << bit);
         address >>= 3;
         address += 0x20;
-        if (!(aCPU->mLowerData[address] & bitmask))
+        if (!(CPU.mLowerData[address] & bitmask))
         {
             PC += (signed char)OPERAND2 + 3;
         }
@@ -458,36 +458,36 @@ static uint8_t jnb_bitaddr_offset(struct em8051 *aCPU)
     return 1;
 }
 
-static uint8_t reti(struct em8051 *aCPU)
+static uint8_t reti()
 {
-    if (aCPU->mInterruptActive)
+    if (CPU.mInterruptActive)
     {
-        if (aCPU->except)
+        if (CPU.except)
         {
             uint8_t hi = 0;
-            if (aCPU->mInterruptActive > 1)
+            if (CPU.mInterruptActive > 1)
                 hi = 1;
-            if (aCPU->int_a[hi] != aCPU->mSFR[REG_ACC])
-                aCPU->except(aCPU, EXCEPTION_IRET_ACC_MISMATCH);
-            if (aCPU->int_sp[hi] != aCPU->mSFR[REG_SP])
-                aCPU->except(aCPU, EXCEPTION_IRET_SP_MISMATCH);    
-            if ((aCPU->int_psw[hi] & (PSWMASK_OV | PSWMASK_RS0 | PSWMASK_RS1 | PSWMASK_AC | PSWMASK_C)) !=                 
-                (aCPU->mSFR[REG_PSW] & (PSWMASK_OV | PSWMASK_RS0 | PSWMASK_RS1 | PSWMASK_AC | PSWMASK_C)))
-                aCPU->except(aCPU, EXCEPTION_IRET_PSW_MISMATCH);
+            if (CPU.int_a[hi] != CPU.mSFR[REG_ACC])
+                CPU.except(EXCEPTION_IRET_ACC_MISMATCH);
+            if (CPU.int_sp[hi] != CPU.mSFR[REG_SP])
+                CPU.except(EXCEPTION_IRET_SP_MISMATCH);
+            if ((CPU.int_psw[hi] & (PSWMASK_OV | PSWMASK_RS0 | PSWMASK_RS1 | PSWMASK_AC | PSWMASK_C)) !=
+                (CPU.mSFR[REG_PSW] & (PSWMASK_OV | PSWMASK_RS0 | PSWMASK_RS1 | PSWMASK_AC | PSWMASK_C)))
+                CPU.except(EXCEPTION_IRET_PSW_MISMATCH);
         }
 
-        if (aCPU->mInterruptActive & 2)
-            aCPU->mInterruptActive &= ~2;
+        if (CPU.mInterruptActive & 2)
+            CPU.mInterruptActive &= ~2;
         else
-            aCPU->mInterruptActive = 0;
+            CPU.mInterruptActive = 0;
     }
 
-    PC = pop_from_stack(aCPU) << 8;
-    PC |= pop_from_stack(aCPU);
+    PC = pop_from_stack() << 8;
+    PC |= pop_from_stack();
     return 1;
 }
 
-static uint8_t rlc_a(struct em8051 *aCPU)
+static uint8_t rlc_a()
 {
     uint8_t carry = CARRY;
     uint8_t new_carry = ACC >> 7;
@@ -497,51 +497,51 @@ static uint8_t rlc_a(struct em8051 *aCPU)
     return 0;
 }
 
-static uint8_t addc_a_imm(struct em8051 *aCPU)
+static uint8_t addc_a_imm()
 {
     uint8_t carry = CARRY;
-    add_solve_flags(aCPU, ACC, OPERAND1, carry);
+    add_solve_flags(ACC, OPERAND1, carry);
     ACC += OPERAND1 + carry;
     PC += 2;
     return 0;
 }
 
-static uint8_t addc_a_mem(struct em8051 *aCPU)
+static uint8_t addc_a_mem()
 {
     uint8_t carry = CARRY;
-    uint8_t value = read_mem(aCPU, OPERAND1);
-    add_solve_flags(aCPU, ACC, value, carry);
+    uint8_t value = read_mem(OPERAND1);
+    add_solve_flags(ACC, value, carry);
     ACC += value + carry;
     PC += 2;
     return 0;
 }
 
-static uint8_t addc_a_indir_rx(struct em8051 *aCPU)
+static uint8_t addc_a_indir_rx()
 {
     uint8_t carry = CARRY;
     uint8_t address = INDIR_RX_ADDRESS;
     if (address > 0x7f)
     {
         uint8_t value = BAD_VALUE;
-        if (aCPU->mUpperData)
+        if (CPU.mUpperData)
         {
-            value = aCPU->mUpperData[address - 0x80];
+            value = CPU.mUpperData[address - 0x80];
         }
 
-        add_solve_flags(aCPU, ACC, value, carry);
+        add_solve_flags(ACC, value, carry);
         ACC += value + carry;
     }
     else
     {
-        add_solve_flags(aCPU, ACC, aCPU->mLowerData[address], carry);
-        ACC += aCPU->mLowerData[address] + carry;
+        add_solve_flags(ACC, CPU.mLowerData[address], carry);
+        ACC += CPU.mLowerData[address] + carry;
     }
     PC++;
     return 0;
 }
 
 
-static uint8_t jc_offset(struct em8051 *aCPU)
+static uint8_t jc_offset()
 {
     if (PSW & PSWMASK_C)
     {
@@ -554,72 +554,72 @@ static uint8_t jc_offset(struct em8051 *aCPU)
     return 1;
 }
 
-static uint8_t orl_mem_a(struct em8051 *aCPU)
+static uint8_t orl_mem_a()
 {
     uint8_t address = OPERAND1;
     if (address > 0x7f)
     {
-        aCPU->mSFR[address - 0x80] |= ACC;
-        if (aCPU->sfrwrite[address - 0x80])
-            aCPU->sfrwrite[address - 0x80](aCPU, address);
+        CPU.mSFR[address - 0x80] |= ACC;
+        if (CPU.sfrwrite[address - 0x80])
+            CPU.sfrwrite[address - 0x80](address);
     }
     else
     {
-        aCPU->mLowerData[address] |= ACC;
+        CPU.mLowerData[address] |= ACC;
     }
     PC += 2;
     return 0;
 }
 
-static uint8_t orl_mem_imm(struct em8051 *aCPU)
+static uint8_t orl_mem_imm()
 {
     uint8_t address = OPERAND1;
     if (address > 0x7f)
     {
-        aCPU->mSFR[address - 0x80] |= OPERAND2;
-        if (aCPU->sfrwrite[address - 0x80])
-            aCPU->sfrwrite[address - 0x80](aCPU, address);
+        CPU.mSFR[address - 0x80] |= OPERAND2;
+        if (CPU.sfrwrite[address - 0x80])
+            CPU.sfrwrite[address - 0x80](address);
     }
     else
     {
-        aCPU->mLowerData[address] |= OPERAND2;
+        CPU.mLowerData[address] |= OPERAND2;
     }
     
     PC += 3;
     return 1;
 }
 
-static uint8_t orl_a_imm(struct em8051 *aCPU)
+static uint8_t orl_a_imm()
 {
     ACC |= OPERAND1;
     PC += 2;
     return 0;
 }
 
-static uint8_t orl_a_mem(struct em8051 *aCPU)
+static uint8_t orl_a_mem()
 {
-    uint8_t value = read_mem(aCPU, OPERAND1);
+    uint8_t value = read_mem(OPERAND1);
     ACC |= value;
     PC += 2;
     return 0;
 }
 
-static uint8_t orl_a_indir_rx(struct em8051 *aCPU)
+static uint8_t orl_a_indir_rx()
 {
     uint8_t address = INDIR_RX_ADDRESS;
     if (address > 0x7f)
     {
         uint8_t value = BAD_VALUE;
-        if (aCPU->mUpperData)
+        if (CPU.mUpperData)
         {
-            value = aCPU->mUpperData[address - 0x80];
+            value = CPU.mUpperData[address - 0x80];
         }
 
         ACC |= value;
     }
     else
     {
-        ACC |= aCPU->mLowerData[address];
+        ACC |= CPU.mLowerData[address];
     }
 
     PC++;
@@ -627,7 +627,7 @@ static uint8_t orl_a_indir_rx(struct em8051 *aCPU)
 }
 
 
-static uint8_t jnc_offset(struct em8051 *aCPU)
+static uint8_t jnc_offset()
 {
     if (PSW & PSWMASK_C)
     {
@@ -640,78 +640,78 @@ static uint8_t jnc_offset(struct em8051 *aCPU)
     return 1;
 }
 
-static uint8_t anl_mem_a(struct em8051 *aCPU)
+static uint8_t anl_mem_a()
 {
     uint8_t address = OPERAND1;
     if (address > 0x7f)
     {
-        aCPU->mSFR[address - 0x80] &= ACC;
-        if (aCPU->sfrwrite[address - 0x80])
-            aCPU->sfrwrite[address - 0x80](aCPU, address);
+        CPU.mSFR[address - 0x80] &= ACC;
+        if (CPU.sfrwrite[address - 0x80])
+            CPU.sfrwrite[address - 0x80](address);
     }
     else
     {
-        aCPU->mLowerData[address] &= ACC;
+        CPU.mLowerData[address] &= ACC;
     }
     PC += 2;
     return 0;
 }
 
-static uint8_t anl_mem_imm(struct em8051 *aCPU)
+static uint8_t anl_mem_imm()
 {
     uint8_t address = OPERAND1;
     if (address > 0x7f)
     {
-        aCPU->mSFR[address - 0x80] &= OPERAND2;
-        if (aCPU->sfrwrite[address - 0x80])
-            aCPU->sfrwrite[address - 0x80](aCPU, address);
+        CPU.mSFR[address - 0x80] &= OPERAND2;
+        if (CPU.sfrwrite[address - 0x80])
+            CPU.sfrwrite[address - 0x80](address);
     }
     else
     {
-        aCPU->mLowerData[address] &= OPERAND2;
+        CPU.mLowerData[address] &= OPERAND2;
     }
     PC += 3;
     return 1;
 }
 
-static uint8_t anl_a_imm(struct em8051 *aCPU)
+static uint8_t anl_a_imm()
 {
     ACC &= OPERAND1;
     PC += 2;
     return 0;
 }
 
-static uint8_t anl_a_mem(struct em8051 *aCPU)
+static uint8_t anl_a_mem()
 {
-    uint8_t value = read_mem(aCPU, OPERAND1);
+    uint8_t value = read_mem(OPERAND1);
     ACC &= value;
     PC += 2;
     return 0;
 }
 
-static uint8_t anl_a_indir_rx(struct em8051 *aCPU)
+static uint8_t anl_a_indir_rx()
 {
     uint8_t address = INDIR_RX_ADDRESS;
     if (address > 0x7f)
     {
         uint8_t value = BAD_VALUE;
-        if (aCPU->mUpperData)
+        if (CPU.mUpperData)
         {
-            value = aCPU->mUpperData[address - 0x80];
+            value = CPU.mUpperData[address - 0x80];
         }
 
         ACC &= value;
     }
     else
     {
-        ACC &= aCPU->mLowerData[address];
+        ACC &= CPU.mLowerData[address];
     }
     PC++;
     return 0;
 }
 
 
-static uint8_t jz_offset(struct em8051 *aCPU)
+static uint8_t jz_offset()
 {
     if (!ACC)
     {
@@ -724,78 +724,78 @@ static uint8_t jz_offset(struct em8051 *aCPU)
     return 1;
 }
 
-static uint8_t xrl_mem_a(struct em8051 *aCPU)
+static uint8_t xrl_mem_a()
 {
     uint8_t address = OPERAND1;
     if (address > 0x7f)
     {
-        aCPU->mSFR[address - 0x80] ^= ACC;
-        if (aCPU->sfrwrite[address - 0x80])
-            aCPU->sfrwrite[address - 0x80](aCPU, address);
+        CPU.mSFR[address - 0x80] ^= ACC;
+        if (CPU.sfrwrite[address - 0x80])
+            CPU.sfrwrite[address - 0x80](address);
     }
     else
     {
-        aCPU->mLowerData[address] ^= ACC;
+        CPU.mLowerData[address] ^= ACC;
     }
     PC += 2;
     return 0;
 }
 
-static uint8_t xrl_mem_imm(struct em8051 *aCPU)
+static uint8_t xrl_mem_imm()
 {
     uint8_t address = OPERAND1;
     if (address > 0x7f)
     {
-        aCPU->mSFR[address - 0x80] ^= OPERAND2;
-        if (aCPU->sfrwrite[address - 0x80])
-            aCPU->sfrwrite[address - 0x80](aCPU, address);
+        CPU.mSFR[address - 0x80] ^= OPERAND2;
+        if (CPU.sfrwrite[address - 0x80])
+            CPU.sfrwrite[address - 0x80](address);
     }
     else
     {
-        aCPU->mLowerData[address] ^= OPERAND2;
+        CPU.mLowerData[address] ^= OPERAND2;
     }
     PC += 3;
     return 1;
 }
 
-static uint8_t xrl_a_imm(struct em8051 *aCPU)
+static uint8_t xrl_a_imm()
 {
     ACC ^= OPERAND1;
     PC += 2;
     return 0;
 }
 
-static uint8_t xrl_a_mem(struct em8051 *aCPU)
+static uint8_t xrl_a_mem()
 {
-    uint8_t value = read_mem(aCPU, OPERAND1);
+    uint8_t value = read_mem(OPERAND1);
     ACC ^= value;
     PC += 2;
     return 0;
 }
 
-static uint8_t xrl_a_indir_rx(struct em8051 *aCPU)
+static uint8_t xrl_a_indir_rx()
 {
     uint8_t address = INDIR_RX_ADDRESS;
     if (address > 0x7f)
     {
         uint8_t value = BAD_VALUE;
-        if (aCPU->mUpperData)
+        if (CPU.mUpperData)
         {
-            value = aCPU->mUpperData[address - 0x80];
+            value = CPU.mUpperData[address - 0x80];
         }
 
         ACC ^= value;
     }
     else
     {
-        ACC ^= aCPU->mLowerData[address];
+        ACC ^= CPU.mLowerData[address];
     }
     PC++;;
     return 0;
 }
 
 
-static uint8_t jnz_offset(struct em8051 *aCPU)
+static uint8_t jnz_offset()
 {
     if (ACC)
     {
@@ -808,7 +808,7 @@ static uint8_t jnz_offset(struct em8051 *aCPU)
     return 1;
 }
 
-static uint8_t orl_c_bitaddr(struct em8051 *aCPU)
+static uint8_t orl_c_bitaddr()
 {
     uint8_t address = OPERAND1;
     uint8_t carry = CARRY;
@@ -818,10 +818,10 @@ static uint8_t orl_c_bitaddr(struct em8051 *aCPU)
         uint8_t bitmask = (1 << bit);
         uint8_t value;
         address &= 0xf8;        
-        if (aCPU->sfrread[address - 0x80])
-            value = aCPU->sfrread[address - 0x80](aCPU, address);
+        if (CPU.sfrread[address - 0x80])
+            value = CPU.sfrread[address - 0x80](address);
         else
-            value = aCPU->mSFR[address - 0x80];
+            value = CPU.mSFR[address - 0x80];
 
         value = (value & bitmask) ? 1 : carry;
 
@@ -834,58 +834,58 @@ static uint8_t orl_c_bitaddr(struct em8051 *aCPU)
         uint8_t value;
         address >>= 3;
         address += 0x20;
-        value = (aCPU->mLowerData[address] & bitmask) ? 1 : carry;
+        value = (CPU.mLowerData[address] & bitmask) ? 1 : carry;
         PSW = (PSW & ~PSWMASK_C) | (PSWMASK_C * value);
     }
     PC += 2;
     return 1;
 }
 
-static uint8_t jmp_indir_a_dptr(struct em8051 *aCPU)
+static uint8_t jmp_indir_a_dptr()
 {
-    PC = ((aCPU->mSFR[REG_DPH] << 8) | (aCPU->mSFR[REG_DPL])) + ACC;
+    PC = ((CPU.mSFR[REG_DPH] << 8) | (CPU.mSFR[REG_DPL])) + ACC;
     return 1;
 }
 
-static uint8_t mov_a_imm(struct em8051 *aCPU)
+static uint8_t mov_a_imm()
 {
     ACC = OPERAND1;
     PC += 2;
     return 0;
 }
 
-static uint8_t mov_mem_imm(struct em8051 *aCPU)
+static uint8_t mov_mem_imm()
 {
     uint8_t address = OPERAND1;
     if (address > 0x7f)
     {
-        aCPU->mSFR[address - 0x80] = OPERAND2;
-        if (aCPU->sfrwrite[address - 0x80])
-            aCPU->sfrwrite[address - 0x80](aCPU, address);
+        CPU.mSFR[address - 0x80] = OPERAND2;
+        if (CPU.sfrwrite[address - 0x80])
+            CPU.sfrwrite[address - 0x80](address);
     }
     else
     {
-        aCPU->mLowerData[address] = OPERAND2;
+        CPU.mLowerData[address] = OPERAND2;
     }
 
     PC += 3;
     return 1;
 }
 
-static uint8_t mov_indir_rx_imm(struct em8051 *aCPU)
+static uint8_t mov_indir_rx_imm()
 {
     uint8_t address = INDIR_RX_ADDRESS;
     uint8_t value = OPERAND1;
     if (address > 0x7f)
     {
-        if (aCPU->mUpperData)
+        if (CPU.mUpperData)
         {
-            aCPU->mUpperData[address - 0x80] = value;
+            CPU.mUpperData[address - 0x80] = value;
         }
     }
     else
     {
-        aCPU->mLowerData[address] = value;
+        CPU.mLowerData[address] = value;
     }
 
     PC += 2;
@@ -893,13 +893,13 @@ static uint8_t mov_indir_rx_imm(struct em8051 *aCPU)
 }
 
 
-static uint8_t sjmp_offset(struct em8051 *aCPU)
+static uint8_t sjmp_offset()
 {
     PC += (signed char)(OPERAND1) + 2;
     return 1;
 }
 
-static uint8_t anl_c_bitaddr(struct em8051 *aCPU)
+static uint8_t anl_c_bitaddr()
 {
     uint8_t address = OPERAND1;
     uint8_t carry = CARRY;
@@ -909,10 +909,10 @@ static uint8_t anl_c_bitaddr(struct em8051 *aCPU)
         uint8_t bitmask = (1 << bit);
         uint8_t value;
         address &= 0xf8;        
-        if (aCPU->sfrread[address - 0x80])
-            value = aCPU->sfrread[address - 0x80](aCPU, address);
+        if (CPU.sfrread[address - 0x80])
+            value = CPU.sfrread[address - 0x80](address);
         else
-            value = aCPU->mSFR[address - 0x80];
+            value = CPU.mSFR[address - 0x80];
 
         value = (value & bitmask) ? carry : 0;
 
@@ -925,14 +925,14 @@ static uint8_t anl_c_bitaddr(struct em8051 *aCPU)
         uint8_t value;
         address >>= 3;
         address += 0x20;
-        value = (aCPU->mLowerData[address] & bitmask) ? carry : 0;
+        value = (CPU.mLowerData[address] & bitmask) ? carry : 0;
         PSW = (PSW & ~PSWMASK_C) | (PSWMASK_C * value);
     }
     PC += 2;
     return 0;
 }
 
-static uint8_t movc_a_indir_a_pc(struct em8051 *aCPU)
+static uint8_t movc_a_indir_a_pc()
 {
     uint16_t address = PC + 1 + ACC;
     ACC = CODEMEM(address);
@@ -940,10 +940,10 @@ static uint8_t movc_a_indir_a_pc(struct em8051 *aCPU)
     return 0;
 }
 
-static uint8_t div_ab(struct em8051 *aCPU)
+static uint8_t div_ab()
 {
     uint8_t a = ACC;
-    uint8_t b = aCPU->mSFR[REG_B];
+    uint8_t b = CPU.mSFR[REG_B];
     uint8_t res;
     PSW &= ~(PSWMASK_C|PSWMASK_OV);
     if (b)
@@ -957,32 +957,32 @@ static uint8_t div_ab(struct em8051 *aCPU)
         PSW |= PSWMASK_OV;
     }
     ACC = a;
-    aCPU->mSFR[REG_B] = b;
+    CPU.mSFR[REG_B] = b;
     PC++;
     return 3;
 }
 
-static uint8_t mov_mem_mem(struct em8051 *aCPU)
+static uint8_t mov_mem_mem()
 {
     uint8_t address1 = OPERAND2;
-    uint8_t value = read_mem(aCPU, OPERAND1);
+    uint8_t value = read_mem(OPERAND1);
 
     if (address1 > 0x7f)
     {
-        aCPU->mSFR[address1 - 0x80] = value;
-        if (aCPU->sfrwrite[address1 - 0x80])
-            aCPU->sfrwrite[address1 - 0x80](aCPU, address1);
+        CPU.mSFR[address1 - 0x80] = value;
+        if (CPU.sfrwrite[address1 - 0x80])
+            CPU.sfrwrite[address1 - 0x80](address1);
     }
     else
     {
-        aCPU->mLowerData[address1] = value;
+        CPU.mLowerData[address1] = value;
     }
 
     PC += 3;
     return 1;
 }
 
-static uint8_t mov_mem_indir_rx(struct em8051 *aCPU)
+static uint8_t mov_mem_indir_rx()
 {
     uint8_t address1 = OPERAND1;
     uint8_t address2 = INDIR_RX_ADDRESS;
@@ -991,19 +991,19 @@ static uint8_t mov_mem_indir_rx(struct em8051 *aCPU)
         if (address2 > 0x7f)
         {
             uint8_t value = BAD_VALUE;
-            if (aCPU->mUpperData)
+            if (CPU.mUpperData)
             {
-                value = aCPU->mUpperData[address2 - 0x80];
+                value = CPU.mUpperData[address2 - 0x80];
             }
-            aCPU->mSFR[address1 - 0x80] = value;
-            if (aCPU->sfrwrite[address1 - 0x80])
-                aCPU->sfrwrite[address1 - 0x80](aCPU, address1);
+            CPU.mSFR[address1 - 0x80] = value;
+            if (CPU.sfrwrite[address1 - 0x80])
+                CPU.sfrwrite[address1 - 0x80](address1);
         }
         else
         {
-            aCPU->mSFR[address1 - 0x80] = aCPU->mLowerData[address2];
-            if (aCPU->sfrwrite[address1 - 0x80])
-                aCPU->sfrwrite[address1 - 0x80](aCPU, address1);
+            CPU.mSFR[address1 - 0x80] = CPU.mLowerData[address2];
+            if (CPU.sfrwrite[address1 - 0x80])
+                CPU.sfrwrite[address1 - 0x80](address1);
         }
     }
     else
@@ -1011,15 +1011,15 @@ static uint8_t mov_mem_indir_rx(struct em8051 *aCPU)
         if (address2 > 0x7f)
         {
             uint8_t value = BAD_VALUE;
-            if (aCPU->mUpperData)
+            if (CPU.mUpperData)
             {
-                value = aCPU->mUpperData[address2 - 0x80];
+                value = CPU.mUpperData[address2 - 0x80];
             }
-            aCPU->mLowerData[address1] = value;
+            CPU.mLowerData[address1] = value;
         }
         else
         {
-            aCPU->mLowerData[address1] = aCPU->mLowerData[address2];
+            CPU.mLowerData[address1] = CPU.mLowerData[address2];
         }
     }
 
@@ -1028,15 +1028,15 @@ static uint8_t mov_mem_indir_rx(struct em8051 *aCPU)
 }
 
 
-static uint8_t mov_dptr_imm(struct em8051 *aCPU)
+static uint8_t mov_dptr_imm()
 {
-    aCPU->mSFR[REG_DPH] = OPERAND1;
-    aCPU->mSFR[REG_DPL] = OPERAND2;
+    CPU.mSFR[REG_DPH] = OPERAND1;
+    CPU.mSFR[REG_DPL] = OPERAND2;
     PC += 3;
     return 1;
 }
 
-static uint8_t mov_bitaddr_c(struct em8051 *aCPU)
+static uint8_t mov_bitaddr_c()
 {
     uint8_t address = OPERAND1;
     uint8_t carry = CARRY;
@@ -1047,9 +1047,9 @@ static uint8_t mov_bitaddr_c(struct em8051 *aCPU)
         uint8_t bit = address & 7;
         uint8_t bitmask = (1 << bit);
         address &= 0xf8;        
-        aCPU->mSFR[address - 0x80] = (aCPU->mSFR[address - 0x80] & ~bitmask) | (carry << bit);
-        if (aCPU->sfrwrite[address - 0x80])
-            aCPU->sfrwrite[address - 0x80](aCPU, address);
+        CPU.mSFR[address - 0x80] = (CPU.mSFR[address - 0x80] & ~bitmask) | (carry << bit);
+        if (CPU.sfrwrite[address - 0x80])
+            CPU.sfrwrite[address - 0x80](address);
     }
     else
     {
@@ -1057,65 +1057,65 @@ static uint8_t mov_bitaddr_c(struct em8051 *aCPU)
         uint8_t bitmask = (1 << bit);
         address >>= 3;
         address += 0x20;
-        aCPU->mLowerData[address] = (aCPU->mLowerData[address] & ~bitmask) | (carry << bit);
+        CPU.mLowerData[address] = (CPU.mLowerData[address] & ~bitmask) | (carry << bit);
     }
     PC += 2;
     return 1;
 }
 
-static uint8_t movc_a_indir_a_dptr(struct em8051 *aCPU)
+static uint8_t movc_a_indir_a_dptr()
 {
-    uint16_t address = (aCPU->mSFR[REG_DPH] << 8) | ((aCPU->mSFR[REG_DPL] << 0) + ACC);
+    uint16_t address = (CPU.mSFR[REG_DPH] << 8) | ((CPU.mSFR[REG_DPL] << 0) + ACC);
     ACC = CODEMEM(address);
     PC++;
     return 1;
 }
 
-static uint8_t subb_a_imm(struct em8051 *aCPU)
+static uint8_t subb_a_imm()
 {
     uint8_t carry = CARRY;
-    sub_solve_flags(aCPU, ACC, OPERAND1 + carry);
+    sub_solve_flags(ACC, OPERAND1 + carry);
     ACC -= OPERAND1 + carry;
     PC += 2;
     return 0;
 }
 
-static uint8_t subb_a_mem(struct em8051 *aCPU)
+static uint8_t subb_a_mem()
 {
     uint8_t carry = CARRY;
-    uint8_t value = read_mem(aCPU, OPERAND1) + carry;
-    sub_solve_flags(aCPU, ACC, value);
+    uint8_t value = read_mem(OPERAND1) + carry;
+    sub_solve_flags(ACC, value);
     ACC -= value;
 
     PC += 2;
     return 0;
 }
-static uint8_t subb_a_indir_rx(struct em8051 *aCPU)
+static uint8_t subb_a_indir_rx()
 {
     uint8_t carry = CARRY;
     uint8_t address = INDIR_RX_ADDRESS;
     if (address > 0x7f)
     {
         uint8_t value = BAD_VALUE;
-        if (aCPU->mUpperData)
+        if (CPU.mUpperData)
         {
-            value = aCPU->mUpperData[address - 0x80];
+            value = CPU.mUpperData[address - 0x80];
         }
 
-        sub_solve_flags(aCPU, ACC, value);
+        sub_solve_flags(ACC, value);
         ACC -= value;
     }
     else
     {
-        sub_solve_flags(aCPU, ACC, aCPU->mLowerData[address] + carry);
-        ACC -= aCPU->mLowerData[address] + carry;
+        sub_solve_flags(ACC, CPU.mLowerData[address] + carry);
+        ACC -= CPU.mLowerData[address] + carry;
     }
     PC++;
     return 0;
 }
 
 
-static uint8_t orl_c_compl_bitaddr(struct em8051 *aCPU)
+static uint8_t orl_c_compl_bitaddr()
 {
     uint8_t address = OPERAND1;
     uint8_t carry = CARRY;
@@ -1125,10 +1125,10 @@ static uint8_t orl_c_compl_bitaddr(struct em8051 *aCPU)
         uint8_t bitmask = (1 << bit);
         uint8_t value;
         address &= 0xf8;        
-        if (aCPU->sfrread[address - 0x80])
-            value = aCPU->sfrread[address - 0x80](aCPU, address);
+        if (CPU.sfrread[address - 0x80])
+            value = CPU.sfrread[address - 0x80](address);
         else
-            value = aCPU->mSFR[address - 0x80];
+            value = CPU.mSFR[address - 0x80];
 
         value = (value & bitmask) ? carry : 1;
 
@@ -1141,14 +1141,14 @@ static uint8_t orl_c_compl_bitaddr(struct em8051 *aCPU)
         uint8_t value;
         address >>= 3;
         address += 0x20;
-        value = (aCPU->mLowerData[address] & bitmask) ? carry : 1;
+        value = (CPU.mLowerData[address] & bitmask) ? carry : 1;
         PSW = (PSW & ~PSWMASK_C) | (PSWMASK_C * value);
     }
     PC += 2;
     return 0;
 }
 
-static uint8_t mov_c_bitaddr(struct em8051 *aCPU)
+static uint8_t mov_c_bitaddr()
 {
     uint8_t address = OPERAND1;
     if (address > 0x7f)
@@ -1157,10 +1157,10 @@ static uint8_t mov_c_bitaddr(struct em8051 *aCPU)
         uint8_t bitmask = (1 << bit);
         uint8_t value;
         address &= 0xf8;        
-        if (aCPU->sfrread[address - 0x80])
-            value = aCPU->sfrread[address - 0x80](aCPU, address);
+        if (CPU.sfrread[address - 0x80])
+            value = CPU.sfrread[address - 0x80](address);
         else
-            value = aCPU->mSFR[address - 0x80];
+            value = CPU.mSFR[address - 0x80];
 
         value = (value & bitmask) ? 1 : 0;
 
@@ -1173,7 +1173,7 @@ static uint8_t mov_c_bitaddr(struct em8051 *aCPU)
         uint8_t value;
         address >>= 3;
         address += 0x20;
-        value = (aCPU->mLowerData[address] & bitmask) ? 1 : 0;
+        value = (CPU.mLowerData[address] & bitmask) ? 1 : 0;
         PSW = (PSW & ~PSWMASK_C) | (PSWMASK_C * value);
     }
 
@@ -1181,50 +1181,50 @@ static uint8_t mov_c_bitaddr(struct em8051 *aCPU)
     return 0;
 }
 
-static uint8_t inc_dptr(struct em8051 *aCPU)
+static uint8_t inc_dptr()
 {
-    aCPU->mSFR[REG_DPL]++;
-    if (!aCPU->mSFR[REG_DPL])
-        aCPU->mSFR[REG_DPH]++;
+    CPU.mSFR[REG_DPL]++;
+    if (!CPU.mSFR[REG_DPL])
+        CPU.mSFR[REG_DPH]++;
     PC++;
     return 1;
 }
 
-static uint8_t mul_ab(struct em8051 *aCPU)
+static uint8_t mul_ab()
 {
     uint8_t a = ACC;
-    uint8_t b = aCPU->mSFR[REG_B];
+    uint8_t b = CPU.mSFR[REG_B];
     uint16_t res = a*b;
     ACC = res & 0xff;
-    aCPU->mSFR[REG_B] = res >> 8;
+    CPU.mSFR[REG_B] = res >> 8;
     PSW &= ~(PSWMASK_C|PSWMASK_OV);
-    if (aCPU->mSFR[REG_B])
+    if (CPU.mSFR[REG_B])
         PSW |= PSWMASK_OV;
     PC++;
     return 3;
 }
 
-static uint8_t mov_indir_rx_mem(struct em8051 *aCPU)
+static uint8_t mov_indir_rx_mem()
 {
     uint8_t address1 = INDIR_RX_ADDRESS;
-    uint8_t value = read_mem(aCPU, OPERAND1);
+    uint8_t value = read_mem(OPERAND1);
     if (address1 > 0x7f)
     {
-        if (aCPU->mUpperData)
+        if (CPU.mUpperData)
         {
-            aCPU->mUpperData[address1 - 0x80] = value;
+            CPU.mUpperData[address1 - 0x80] = value;
         }
     }
     else
     {
-        aCPU->mLowerData[address1] = value;
+        CPU.mLowerData[address1] = value;
     }
     PC += 2;
     return 1;
 }
 
 
-static uint8_t anl_c_compl_bitaddr(struct em8051 *aCPU)
+static uint8_t anl_c_compl_bitaddr()
 {
     uint8_t address = OPERAND1;
     uint8_t carry = CARRY;
@@ -1234,10 +1234,10 @@ static uint8_t anl_c_compl_bitaddr(struct em8051 *aCPU)
         uint8_t bitmask = (1 << bit);
         uint8_t value;
         address &= 0xf8;        
-        if (aCPU->sfrread[address - 0x80])
-            value = aCPU->sfrread[address - 0x80](aCPU, address);
+        if (CPU.sfrread[address - 0x80])
+            value = CPU.sfrread[address - 0x80](address);
         else
-            value = aCPU->mSFR[address - 0x80];
+            value = CPU.mSFR[address - 0x80];
 
         value = (value & bitmask) ? 0 : carry;
 
@@ -1250,7 +1250,7 @@ static uint8_t anl_c_compl_bitaddr(struct em8051 *aCPU)
         uint8_t value;
         address >>= 3;
         address += 0x20;
-        value = (aCPU->mLowerData[address] & bitmask) ? 0 : carry;
+        value = (CPU.mLowerData[address] & bitmask) ? 0 : carry;
         PSW = (PSW & ~PSWMASK_C) | (PSWMASK_C * value);
     }
     PC += 2;
@@ -1258,7 +1258,7 @@ static uint8_t anl_c_compl_bitaddr(struct em8051 *aCPU)
 }
 
 
-static uint8_t cpl_bitaddr(struct em8051 *aCPU)
+static uint8_t cpl_bitaddr()
 {
     uint8_t address = OPERAND1;
     if (address > 0x7f)
@@ -1268,9 +1268,9 @@ static uint8_t cpl_bitaddr(struct em8051 *aCPU)
         uint8_t bit = address & 7;
         uint8_t bitmask = (1 << bit);
         address &= 0xf8;        
-        aCPU->mSFR[address - 0x80] ^= bitmask;
-        if (aCPU->sfrwrite[address - 0x80])
-            aCPU->sfrwrite[address - 0x80](aCPU, address);
+        CPU.mSFR[address - 0x80] ^= bitmask;
+        if (CPU.sfrwrite[address - 0x80])
+            CPU.sfrwrite[address - 0x80](address);
     }
     else
     {
@@ -1278,20 +1278,20 @@ static uint8_t cpl_bitaddr(struct em8051 *aCPU)
         uint8_t bitmask = (1 << bit);
         address >>= 3;
         address += 0x20;
-        aCPU->mLowerData[address] ^= bitmask;
+        CPU.mLowerData[address] ^= bitmask;
     }
     PC += 2;
     return 0;
 }
 
-static uint8_t cpl_c(struct em8051 *aCPU)
+static uint8_t cpl_c()
 {
     PSW ^= PSWMASK_C;
     PC++;
     return 0;
 }
 
-static uint8_t cjne_a_imm_offset(struct em8051 *aCPU)
+static uint8_t cjne_a_imm_offset()
 {
     uint8_t value = OPERAND1;
 
@@ -1315,20 +1315,20 @@ static uint8_t cjne_a_imm_offset(struct em8051 *aCPU)
     return 1;
 }
 
-static uint8_t cjne_a_mem_offset(struct em8051 *aCPU)
+static uint8_t cjne_a_mem_offset()
 {
     uint8_t address = OPERAND1;
     uint8_t value;
     if (address > 0x7f)
     {
-        if (aCPU->sfrread[address - 0x80])
-            value = aCPU->sfrread[address - 0x80](aCPU, address);
+        if (CPU.sfrread[address - 0x80])
+            value = CPU.sfrread[address - 0x80](address);
         else
-            value = aCPU->mSFR[address - 0x80];
+            value = CPU.mSFR[address - 0x80];
     }
     else
     {
-        value = aCPU->mLowerData[address];
+        value = CPU.mLowerData[address];
     }  
 
     if (ACC < value)
@@ -1350,21 +1350,21 @@ static uint8_t cjne_a_mem_offset(struct em8051 *aCPU)
     }
     return 1;
 }
-static uint8_t cjne_indir_rx_imm_offset(struct em8051 *aCPU)
+static uint8_t cjne_indir_rx_imm_offset()
 {
     uint8_t address = INDIR_RX_ADDRESS;
     uint8_t value1 = BAD_VALUE;
     uint8_t value2 = OPERAND1;
     if (address > 0x7f)
     {
-        if (aCPU->mUpperData)
+        if (CPU.mUpperData)
         {
-            value1 = aCPU->mUpperData[address - 0x80];
+            value1 = CPU.mUpperData[address - 0x80];
         }
     }
     else
     {
-        value1 = aCPU->mLowerData[address];
+        value1 = CPU.mLowerData[address];
     }  
 
     if (value1 < value2)
@@ -1387,16 +1387,16 @@ static uint8_t cjne_indir_rx_imm_offset(struct em8051 *aCPU)
     return 1;
 }
 
-static uint8_t push_mem(struct em8051 *aCPU)
+static uint8_t push_mem()
 {
-    uint8_t value = read_mem(aCPU, OPERAND1);
-    push_to_stack(aCPU, value);   
+    uint8_t value = read_mem(OPERAND1);
+    push_to_stack(value);
     PC += 2;
     return 1;
 }
 
 
-static uint8_t clr_bitaddr(struct em8051 *aCPU)
+static uint8_t clr_bitaddr()
 {
     uint8_t address = OPERAND1;
     if (address > 0x7f)
@@ -1406,9 +1406,9 @@ static uint8_t clr_bitaddr(struct em8051 *aCPU)
         uint8_t bit = address & 7;
         uint8_t bitmask = (1 << bit);
         address &= 0xf8;        
-        aCPU->mSFR[address - 0x80] &= ~bitmask;
-        if (aCPU->sfrwrite[address - 0x80])
-            aCPU->sfrwrite[address - 0x80](aCPU, address);
+        CPU.mSFR[address - 0x80] &= ~bitmask;
+        if (CPU.sfrwrite[address - 0x80])
+            CPU.sfrwrite[address - 0x80](address);
     }
     else
     {
@@ -1416,63 +1416,63 @@ static uint8_t clr_bitaddr(struct em8051 *aCPU)
         uint8_t bitmask = (1 << bit);
         address >>= 3;
         address += 0x20;
-        aCPU->mLowerData[address] &= ~bitmask;
+        CPU.mLowerData[address] &= ~bitmask;
     }
     PC += 2;
     return 0;
 }
 
-static uint8_t clr_c(struct em8051 *aCPU)
+static uint8_t clr_c()
 {
     PSW &= ~PSWMASK_C;
     PC++;
     return 0;
 }
 
-static uint8_t swap_a(struct em8051 *aCPU)
+static uint8_t swap_a()
 {
     ACC = (ACC << 4) | (ACC >> 4);
     PC++;
     return 0;
 }
 
-static uint8_t xch_a_mem(struct em8051 *aCPU)
+static uint8_t xch_a_mem()
 {
     uint8_t address = OPERAND1;
-    uint8_t value = read_mem(aCPU, OPERAND1);
+    uint8_t value = read_mem(OPERAND1);
     if (address > 0x7f)
     {
-        aCPU->mSFR[address - 0x80] = ACC;
+        CPU.mSFR[address - 0x80] = ACC;
         ACC = value;
-        if (aCPU->sfrwrite[address - 0x80])
-            aCPU->sfrwrite[address - 0x80](aCPU, address);
+        if (CPU.sfrwrite[address - 0x80])
+            CPU.sfrwrite[address - 0x80](address);
     }
     else
     {
-        aCPU->mLowerData[address] = ACC;
+        CPU.mLowerData[address] = ACC;
         ACC = value;
     }
     PC += 2;
     return 0;
 }
 
-static uint8_t xch_a_indir_rx(struct em8051 *aCPU)
+static uint8_t xch_a_indir_rx()
 {
     uint8_t address = INDIR_RX_ADDRESS;
     if (address > 0x7f)
     {
         uint8_t value;
-        if (aCPU->mUpperData)
+        if (CPU.mUpperData)
         {
-            value = aCPU->mUpperData[address - 0x80];
-            aCPU->mUpperData[address - 0x80] = ACC;
+            value = CPU.mUpperData[address - 0x80];
+            CPU.mUpperData[address - 0x80] = ACC;
             ACC = value;
         }
     }
     else
     {
-        uint8_t value = aCPU->mLowerData[address];
-        aCPU->mLowerData[address] = ACC;
+        uint8_t value = CPU.mLowerData[address];
+        CPU.mLowerData[address] = ACC;
         ACC = value;
     }
     PC++;
@@ -1480,25 +1480,25 @@ static uint8_t xch_a_indir_rx(struct em8051 *aCPU)
 }
 
 
-static uint8_t pop_mem(struct em8051 *aCPU)
+static uint8_t pop_mem()
 {
     uint8_t address = OPERAND1;
     if (address > 0x7f)
     {
-        aCPU->mSFR[address - 0x80] = pop_from_stack(aCPU);
-        if (aCPU->sfrwrite[address - 0x80])
-            aCPU->sfrwrite[address - 0x80](aCPU, address);
+        CPU.mSFR[address - 0x80] = pop_from_stack();
+        if (CPU.sfrwrite[address - 0x80])
+            CPU.sfrwrite[address - 0x80](address);
     }
     else
     {
-        aCPU->mLowerData[address] = pop_from_stack(aCPU);
+        CPU.mLowerData[address] = pop_from_stack();
     }
 
     PC += 2;
     return 1;
 }
 
-static uint8_t setb_bitaddr(struct em8051 *aCPU)
+static uint8_t setb_bitaddr()
 {
     uint8_t address = OPERAND1;
     if (address > 0x7f)
@@ -1508,9 +1508,9 @@ static uint8_t setb_bitaddr(struct em8051 *aCPU)
         uint8_t bit = address & 7;
         uint8_t bitmask = (1 << bit);
         address &= 0xf8;        
-        aCPU->mSFR[address - 0x80] |= bitmask;
-        if (aCPU->sfrwrite[address - 0x80])
-            aCPU->sfrwrite[address - 0x80](aCPU, address);
+        CPU.mSFR[address - 0x80] |= bitmask;
+        if (CPU.sfrwrite[address - 0x80])
+            CPU.sfrwrite[address - 0x80](address);
     }
     else
     {
@@ -1518,20 +1518,20 @@ static uint8_t setb_bitaddr(struct em8051 *aCPU)
         uint8_t bitmask = (1 << bit);
         address >>= 3;
         address += 0x20;
-        aCPU->mLowerData[address] |= bitmask;
+        CPU.mLowerData[address] |= bitmask;
     }
     PC += 2;
     return 0;
 }
 
-static uint8_t setb_c(struct em8051 *aCPU)
+static uint8_t setb_c()
 {
     PSW |= PSWMASK_C;
     PC++;
     return 0;
 }
 
-static uint8_t da_a(struct em8051 *aCPU)
+static uint8_t da_a()
 {
     // data sheets for this operation are a bit unclear..
     // - should AC (or C) ever be cleared?
@@ -1562,21 +1562,21 @@ static uint8_t da_a(struct em8051 *aCPU)
     return 0;
 }
 
-static uint8_t djnz_mem_offset(struct em8051 *aCPU)
+static uint8_t djnz_mem_offset()
 {
     uint8_t address = OPERAND1;
     uint8_t value;
     if (address > 0x7f)
     {
-        aCPU->mSFR[address - 0x80]--;
-        value = aCPU->mSFR[address - 0x80];
-        if (aCPU->sfrwrite[address - 0x80])
-            aCPU->sfrwrite[address - 0x80](aCPU, address);
+        CPU.mSFR[address - 0x80]--;
+        value = CPU.mSFR[address - 0x80];
+        if (CPU.sfrwrite[address - 0x80])
+            CPU.sfrwrite[address - 0x80](address);
     }
     else
     {
-        aCPU->mLowerData[address]--;
-        value = aCPU->mLowerData[address];
+        CPU.mLowerData[address]--;
+        value = CPU.mLowerData[address];
     }
     if (value)
     {
@@ -1589,23 +1589,23 @@ static uint8_t djnz_mem_offset(struct em8051 *aCPU)
     return 1;
 }
 
-static uint8_t xchd_a_indir_rx(struct em8051 *aCPU)
+static uint8_t xchd_a_indir_rx()
 {
     uint8_t address = INDIR_RX_ADDRESS;
     if (address > 0x7f)
     {
         uint8_t value;
-        if (aCPU->mUpperData)
+        if (CPU.mUpperData)
         {
-            value = aCPU->mUpperData[address - 0x80];
-            aCPU->mUpperData[address - 0x80] = (aCPU->mUpperData[address - 0x80] & 0xf0) | (ACC & 0x0f);
+            value = CPU.mUpperData[address - 0x80];
+            CPU.mUpperData[address - 0x80] = (CPU.mUpperData[address - 0x80] & 0xf0) | (ACC & 0x0f);
             ACC = (ACC & 0xf0) | (value & 0x0f);
         }
     }
     else
     {
-        uint8_t value = aCPU->mLowerData[address];
-        aCPU->mLowerData[address] = (aCPU->mLowerData[address] & 0x0f) | (ACC & 0x0f);
+        uint8_t value = CPU.mLowerData[address];
+        CPU.mLowerData[address] = (CPU.mLowerData[address] & 0x0f) | (ACC & 0x0f);
         ACC = (ACC & 0xf0) | (value & 0x0f);
     }
     PC++;
@@ -1613,32 +1613,32 @@ static uint8_t xchd_a_indir_rx(struct em8051 *aCPU)
 }
 
 
-static uint8_t movx_a_indir_dptr(struct em8051 *aCPU)
+static uint8_t movx_a_indir_dptr()
 {
-    uint16_t dptr = (aCPU->mSFR[REG_DPH] << 8) | aCPU->mSFR[REG_DPL];
-    if (aCPU->xread)
+    uint16_t dptr = (CPU.mSFR[REG_DPH] << 8) | CPU.mSFR[REG_DPL];
+    if (CPU.xread)
     {
-        ACC = aCPU->xread(aCPU, dptr);
+        ACC = CPU.xread(dptr);
     }
     else
     {
-        if (aCPU->mExtData)
+        if (CPU.mExtData)
             ACC = EXTDATA(dptr);
     }
     PC++;
     return 1;
 }
 
-static uint8_t movx_a_indir_rx(struct em8051 *aCPU)
+static uint8_t movx_a_indir_rx()
 {
     uint16_t address = INDIR_RX_ADDRESS;
-    if (aCPU->xread)
+    if (CPU.xread)
     {
-        ACC = aCPU->xread(aCPU, address);
+        ACC = CPU.xread(address);
     }
     else
     {
-        if (aCPU->mExtData)
+        if (CPU.mExtData)
             ACC = EXTDATA(address);
     }
 
@@ -1646,43 +1646,43 @@ static uint8_t movx_a_indir_rx(struct em8051 *aCPU)
     return 1;
 }
 
-static uint8_t clr_a(struct em8051 *aCPU)
+static uint8_t clr_a()
 {
     ACC = 0;
     PC++;
     return 0;
 }
 
-static uint8_t mov_a_mem(struct em8051 *aCPU)
+static uint8_t mov_a_mem()
 {
     // mov a,acc is not a valid instruction
     uint8_t address = OPERAND1;
-    uint8_t value = read_mem(aCPU, address);
+    uint8_t value = read_mem(address);
     if (REG_ACC == address - 0x80)
-        if (aCPU->except)
-            aCPU->except(aCPU, EXCEPTION_ACC_TO_A);
+        if (CPU.except)
+            CPU.except(EXCEPTION_ACC_TO_A);
     ACC = value;
 
     PC += 2;
     return 0;
 }
 
-static uint8_t mov_a_indir_rx(struct em8051 *aCPU)
+static uint8_t mov_a_indir_rx()
 {
     uint8_t address = INDIR_RX_ADDRESS;
     if (address > 0x7f)
     {
         uint8_t value = BAD_VALUE;
-        if (aCPU->mUpperData)
+        if (CPU.mUpperData)
         {
-            value = aCPU->mUpperData[address - 0x80];
+            value = CPU.mUpperData[address - 0x80];
         }
 
         ACC = value;
     }
     else
     {
-        ACC = aCPU->mLowerData[address];
+        ACC = CPU.mLowerData[address];
     }
 
     PC++;
@@ -1690,16 +1690,16 @@ static uint8_t mov_a_indir_rx(struct em8051 *aCPU)
 }
 
 
-static uint8_t movx_indir_dptr_a(struct em8051 *aCPU)
+static uint8_t movx_indir_dptr_a()
 {
-    uint16_t dptr = (aCPU->mSFR[REG_DPH] << 8) | aCPU->mSFR[REG_DPL];
-    if (aCPU->xwrite)
+    uint16_t dptr = (CPU.mSFR[REG_DPH] << 8) | CPU.mSFR[REG_DPL];
+    if (CPU.xwrite)
     {
-        aCPU->xwrite(aCPU, dptr, ACC);
+        CPU.xwrite(dptr, ACC);
     }
     else
     {
-        if (aCPU->mExtData)
+        if (CPU.mExtData)
             EXTDATA(dptr) = ACC;
     }
 
@@ -1707,17 +1707,17 @@ static uint8_t movx_indir_dptr_a(struct em8051 *aCPU)
     return 1;
 }
 
-static uint8_t movx_indir_rx_a(struct em8051 *aCPU)
+static uint8_t movx_indir_rx_a()
 {
     uint16_t address = INDIR_RX_ADDRESS;
 
-    if (aCPU->xwrite)
+    if (CPU.xwrite)
     {
-        aCPU->xwrite(aCPU, address, ACC);
+        CPU.xwrite(address, ACC);
     }
     else
     {
-        if (aCPU->mExtData)
+        if (CPU.mExtData)
             EXTDATA(address) = ACC;
     }
 
@@ -1725,168 +1725,168 @@ static uint8_t movx_indir_rx_a(struct em8051 *aCPU)
     return 1;
 }
 
-static uint8_t cpl_a(struct em8051 *aCPU)
+static uint8_t cpl_a()
 {
     ACC = ~ACC;
     PC++;
     return 0;
 }
 
-static uint8_t mov_mem_a(struct em8051 *aCPU)
+static uint8_t mov_mem_a()
 {
     uint8_t address = OPERAND1;
     if (address > 0x7f)
     {
-        aCPU->mSFR[address - 0x80] = ACC;
-        if (aCPU->sfrwrite[address - 0x80])
-            aCPU->sfrwrite[address - 0x80](aCPU, address);
+        CPU.mSFR[address - 0x80] = ACC;
+        if (CPU.sfrwrite[address - 0x80])
+            CPU.sfrwrite[address - 0x80](address);
     }
     else
     {
-        aCPU->mLowerData[address] = ACC;
+        CPU.mLowerData[address] = ACC;
     }
     PC += 2;
     return 0;
 }
 
-static uint8_t mov_indir_rx_a(struct em8051 *aCPU)
+static uint8_t mov_indir_rx_a()
 {
     uint8_t address = INDIR_RX_ADDRESS;
     if (address > 0x7f)
     {
-        if (aCPU->mUpperData)
-            aCPU->mUpperData[address - 0x80] = ACC;
+        if (CPU.mUpperData)
+            CPU.mUpperData[address - 0x80] = ACC;
     }
     else
     {
-        aCPU->mLowerData[address] = ACC;
+        CPU.mLowerData[address] = ACC;
     }
 
     PC++;
     return 0;
 }
 
-static uint8_t nop(struct em8051 *aCPU)
+static uint8_t nop()
 {
     if (CODEMEM(PC) != 0)
-        if (aCPU->except)
-            aCPU->except(aCPU, EXCEPTION_ILLEGAL_OPCODE);
+        if (CPU.except)
+            CPU.except(EXCEPTION_ILLEGAL_OPCODE);
     PC++;
     return 0;
 }
 
-static uint8_t inc_rx(struct em8051 *aCPU)
+static uint8_t inc_rx()
 {
     uint8_t rx = RX_ADDRESS;
-    aCPU->mLowerData[rx]++;
+    CPU.mLowerData[rx]++;
     PC++;
     return 0;
 }
 
-static uint8_t dec_rx(struct em8051 *aCPU)
+static uint8_t dec_rx()
 {
     uint8_t rx = RX_ADDRESS;
-    aCPU->mLowerData[rx]--;
+    CPU.mLowerData[rx]--;
     PC++;
     return 0;
 }
 
-static uint8_t add_a_rx(struct em8051 *aCPU)
+static uint8_t add_a_rx()
 {
     uint8_t rx = RX_ADDRESS;
-    add_solve_flags(aCPU, aCPU->mLowerData[rx], ACC, 0);
-    ACC += aCPU->mLowerData[rx];
+    add_solve_flags(CPU.mLowerData[rx], ACC, 0);
+    ACC += CPU.mLowerData[rx];
     PC++;
     return 0;
 }
 
-static uint8_t addc_a_rx(struct em8051 *aCPU)
+static uint8_t addc_a_rx()
 {
     uint8_t rx = RX_ADDRESS;
     uint8_t carry = CARRY;
-    add_solve_flags(aCPU, aCPU->mLowerData[rx], ACC, carry);
-    ACC += aCPU->mLowerData[rx] + carry;
+    add_solve_flags(CPU.mLowerData[rx], ACC, carry);
+    ACC += CPU.mLowerData[rx] + carry;
     PC++;
     return 0;
 }
 
-static uint8_t orl_a_rx(struct em8051 *aCPU)
+static uint8_t orl_a_rx()
 {
     uint8_t rx = RX_ADDRESS;
-    ACC |= aCPU->mLowerData[rx];
+    ACC |= CPU.mLowerData[rx];
     PC++;
     return 0;
 }
 
-static uint8_t anl_a_rx(struct em8051 *aCPU)
+static uint8_t anl_a_rx()
 {
     uint8_t rx = RX_ADDRESS;
-    ACC &= aCPU->mLowerData[rx];
+    ACC &= CPU.mLowerData[rx];
     PC++;
     return 0;
 }
 
-static uint8_t xrl_a_rx(struct em8051 *aCPU)
+static uint8_t xrl_a_rx()
 {
     uint8_t rx = RX_ADDRESS;
-    ACC ^= aCPU->mLowerData[rx];    
+    ACC ^= CPU.mLowerData[rx];
     PC++;
     return 0;
 }
 
 
-static uint8_t mov_rx_imm(struct em8051 *aCPU)
+static uint8_t mov_rx_imm()
 {
     uint8_t rx = RX_ADDRESS;
-    aCPU->mLowerData[rx] = OPERAND1;
+    CPU.mLowerData[rx] = OPERAND1;
     PC += 2;
     return 0;
 }
 
-static uint8_t mov_mem_rx(struct em8051 *aCPU)
+static uint8_t mov_mem_rx()
 {
     uint8_t rx = RX_ADDRESS;
     uint8_t address = OPERAND1;
     if (address > 0x7f)
     {
-        aCPU->mSFR[address - 0x80] = aCPU->mLowerData[rx];
-        if (aCPU->sfrwrite[address - 0x80])
-            aCPU->sfrwrite[address - 0x80](aCPU, address);
+        CPU.mSFR[address - 0x80] = CPU.mLowerData[rx];
+        if (CPU.sfrwrite[address - 0x80])
+            CPU.sfrwrite[address - 0x80](address);
     }
     else
     {
-        aCPU->mLowerData[address] = aCPU->mLowerData[rx];
+        CPU.mLowerData[address] = CPU.mLowerData[rx];
     }
     PC += 2;
     return 1;
 }
 
-static uint8_t subb_a_rx(struct em8051 *aCPU)
+static uint8_t subb_a_rx()
 {
     uint8_t rx = RX_ADDRESS;
     uint8_t carry = CARRY;
-    sub_solve_flags(aCPU, ACC, aCPU->mLowerData[rx] + carry);
-    ACC -= aCPU->mLowerData[rx] + carry;
+    sub_solve_flags(ACC, CPU.mLowerData[rx] + carry);
+    ACC -= CPU.mLowerData[rx] + carry;
     PC++;
     return 0;
 }
 
-static uint8_t mov_rx_mem(struct em8051 *aCPU)
+static uint8_t mov_rx_mem()
 {
     uint8_t rx = RX_ADDRESS;
-    uint8_t value = read_mem(aCPU, OPERAND1);
-    aCPU->mLowerData[rx] = value;
+    uint8_t value = read_mem(OPERAND1);
+    CPU.mLowerData[rx] = value;
 
     PC += 2;
     return 1;
 }
 
-static uint8_t cjne_rx_imm_offset(struct em8051 *aCPU)
+static uint8_t cjne_rx_imm_offset()
 {
     uint8_t rx = RX_ADDRESS;
     uint8_t value = OPERAND1;
     
-    if (aCPU->mLowerData[rx] < value)
+    if (CPU.mLowerData[rx] < value)
     {
         PSW |= PSWMASK_C;
     }
@@ -1895,7 +1895,7 @@ static uint8_t cjne_rx_imm_offset(struct em8051 *aCPU)
         PSW &= ~PSWMASK_C;
     }
 
-    if (aCPU->mLowerData[rx] != value)
+    if (CPU.mLowerData[rx] != value)
     {
         PC += (signed char)OPERAND2 + 3;
     }
@@ -1906,21 +1906,21 @@ static uint8_t cjne_rx_imm_offset(struct em8051 *aCPU)
     return 1;
 }
 
-static uint8_t xch_a_rx(struct em8051 *aCPU)
+static uint8_t xch_a_rx()
 {
     uint8_t rx = RX_ADDRESS;
     uint8_t a = ACC;
-    ACC = aCPU->mLowerData[rx];
-    aCPU->mLowerData[rx] = a;
+    ACC = CPU.mLowerData[rx];
+    CPU.mLowerData[rx] = a;
     PC++;
     return 0;
 }
 
-static uint8_t djnz_rx_offset(struct em8051 *aCPU)
+static uint8_t djnz_rx_offset()
 {
     uint8_t rx = RX_ADDRESS;
-    aCPU->mLowerData[rx]--;
-    if (aCPU->mLowerData[rx])
+    CPU.mLowerData[rx]--;
+    if (CPU.mLowerData[rx])
     {
         PC += (signed char)OPERAND1 + 2;
     }
@@ -1931,202 +1931,202 @@ static uint8_t djnz_rx_offset(struct em8051 *aCPU)
     return 1;
 }
 
-static uint8_t mov_a_rx(struct em8051 *aCPU)
+static uint8_t mov_a_rx()
 {
     uint8_t rx = RX_ADDRESS;
-    ACC = aCPU->mLowerData[rx];
+    ACC = CPU.mLowerData[rx];
 
     PC++;
     return 0;
 }
 
-static uint8_t mov_rx_a(struct em8051 *aCPU)
+static uint8_t mov_rx_a()
 {
     uint8_t rx = RX_ADDRESS;
-    aCPU->mLowerData[rx] = ACC;
+    CPU.mLowerData[rx] = ACC;
     PC++;
     return 0;
 }
 
-void op_setptrs(struct em8051 *aCPU)
+void op_setptrs()
 {
     uint8_t i;
     for (i = 0; i < 8; i++)
     {
-        aCPU->op[0x08 + i] = &inc_rx;
-        aCPU->op[0x18 + i] = &dec_rx;
-        aCPU->op[0x28 + i] = &add_a_rx;
-        aCPU->op[0x38 + i] = &addc_a_rx;
-        aCPU->op[0x48 + i] = &orl_a_rx;
-        aCPU->op[0x58 + i] = &anl_a_rx;
-        aCPU->op[0x68 + i] = &xrl_a_rx;
-        aCPU->op[0x78 + i] = &mov_rx_imm;
-        aCPU->op[0x88 + i] = &mov_mem_rx;
-        aCPU->op[0x98 + i] = &subb_a_rx;
-        aCPU->op[0xa8 + i] = &mov_rx_mem;
-        aCPU->op[0xb8 + i] = &cjne_rx_imm_offset;
-        aCPU->op[0xc8 + i] = &xch_a_rx;
-        aCPU->op[0xd8 + i] = &djnz_rx_offset;
-        aCPU->op[0xe8 + i] = &mov_a_rx;
-        aCPU->op[0xf8 + i] = &mov_rx_a;
+        CPU.op[0x08 + i] = &inc_rx;
+        CPU.op[0x18 + i] = &dec_rx;
+        CPU.op[0x28 + i] = &add_a_rx;
+        CPU.op[0x38 + i] = &addc_a_rx;
+        CPU.op[0x48 + i] = &orl_a_rx;
+        CPU.op[0x58 + i] = &anl_a_rx;
+        CPU.op[0x68 + i] = &xrl_a_rx;
+        CPU.op[0x78 + i] = &mov_rx_imm;
+        CPU.op[0x88 + i] = &mov_mem_rx;
+        CPU.op[0x98 + i] = &subb_a_rx;
+        CPU.op[0xa8 + i] = &mov_rx_mem;
+        CPU.op[0xb8 + i] = &cjne_rx_imm_offset;
+        CPU.op[0xc8 + i] = &xch_a_rx;
+        CPU.op[0xd8 + i] = &djnz_rx_offset;
+        CPU.op[0xe8 + i] = &mov_a_rx;
+        CPU.op[0xf8 + i] = &mov_rx_a;
     }
-    aCPU->op[0x00] = &nop;
-    aCPU->op[0x01] = &ajmp_offset;
-    aCPU->op[0x02] = &ljmp_address;
-    aCPU->op[0x03] = &rr_a;
-    aCPU->op[0x04] = &inc_a;
-    aCPU->op[0x05] = &inc_mem;
-    aCPU->op[0x06] = &inc_indir_rx;
-    aCPU->op[0x07] = &inc_indir_rx;
+    CPU.op[0x00] = &nop;
+    CPU.op[0x01] = &ajmp_offset;
+    CPU.op[0x02] = &ljmp_address;
+    CPU.op[0x03] = &rr_a;
+    CPU.op[0x04] = &inc_a;
+    CPU.op[0x05] = &inc_mem;
+    CPU.op[0x06] = &inc_indir_rx;
+    CPU.op[0x07] = &inc_indir_rx;
 
-    aCPU->op[0x10] = &jbc_bitaddr_offset;
-    aCPU->op[0x11] = &acall_offset;
-    aCPU->op[0x12] = &lcall_address;
-    aCPU->op[0x13] = &rrc_a;
-    aCPU->op[0x14] = &dec_a;
-    aCPU->op[0x15] = &dec_mem;
-    aCPU->op[0x16] = &dec_indir_rx;
-    aCPU->op[0x17] = &dec_indir_rx;
+    CPU.op[0x10] = &jbc_bitaddr_offset;
+    CPU.op[0x11] = &acall_offset;
+    CPU.op[0x12] = &lcall_address;
+    CPU.op[0x13] = &rrc_a;
+    CPU.op[0x14] = &dec_a;
+    CPU.op[0x15] = &dec_mem;
+    CPU.op[0x16] = &dec_indir_rx;
+    CPU.op[0x17] = &dec_indir_rx;
 
-    aCPU->op[0x20] = &jb_bitaddr_offset;
-    aCPU->op[0x21] = &ajmp_offset;
-    aCPU->op[0x22] = &ret;
-    aCPU->op[0x23] = &rl_a;
-    aCPU->op[0x24] = &add_a_imm;
-    aCPU->op[0x25] = &add_a_mem;
-    aCPU->op[0x26] = &add_a_indir_rx;
-    aCPU->op[0x27] = &add_a_indir_rx;
+    CPU.op[0x20] = &jb_bitaddr_offset;
+    CPU.op[0x21] = &ajmp_offset;
+    CPU.op[0x22] = &ret;
+    CPU.op[0x23] = &rl_a;
+    CPU.op[0x24] = &add_a_imm;
+    CPU.op[0x25] = &add_a_mem;
+    CPU.op[0x26] = &add_a_indir_rx;
+    CPU.op[0x27] = &add_a_indir_rx;
 
-    aCPU->op[0x30] = &jnb_bitaddr_offset;
-    aCPU->op[0x31] = &acall_offset;
-    aCPU->op[0x32] = &reti;
-    aCPU->op[0x33] = &rlc_a;
-    aCPU->op[0x34] = &addc_a_imm;
-    aCPU->op[0x35] = &addc_a_mem;
-    aCPU->op[0x36] = &addc_a_indir_rx;
-    aCPU->op[0x37] = &addc_a_indir_rx;
+    CPU.op[0x30] = &jnb_bitaddr_offset;
+    CPU.op[0x31] = &acall_offset;
+    CPU.op[0x32] = &reti;
+    CPU.op[0x33] = &rlc_a;
+    CPU.op[0x34] = &addc_a_imm;
+    CPU.op[0x35] = &addc_a_mem;
+    CPU.op[0x36] = &addc_a_indir_rx;
+    CPU.op[0x37] = &addc_a_indir_rx;
 
-    aCPU->op[0x40] = &jc_offset;
-    aCPU->op[0x41] = &ajmp_offset;
-    aCPU->op[0x42] = &orl_mem_a;
-    aCPU->op[0x43] = &orl_mem_imm;
-    aCPU->op[0x44] = &orl_a_imm;
-    aCPU->op[0x45] = &orl_a_mem;
-    aCPU->op[0x46] = &orl_a_indir_rx;
-    aCPU->op[0x47] = &orl_a_indir_rx;
+    CPU.op[0x40] = &jc_offset;
+    CPU.op[0x41] = &ajmp_offset;
+    CPU.op[0x42] = &orl_mem_a;
+    CPU.op[0x43] = &orl_mem_imm;
+    CPU.op[0x44] = &orl_a_imm;
+    CPU.op[0x45] = &orl_a_mem;
+    CPU.op[0x46] = &orl_a_indir_rx;
+    CPU.op[0x47] = &orl_a_indir_rx;
 
-    aCPU->op[0x50] = &jnc_offset;
-    aCPU->op[0x51] = &acall_offset;
-    aCPU->op[0x52] = &anl_mem_a;
-    aCPU->op[0x53] = &anl_mem_imm;
-    aCPU->op[0x54] = &anl_a_imm;
-    aCPU->op[0x55] = &anl_a_mem;
-    aCPU->op[0x56] = &anl_a_indir_rx;
-    aCPU->op[0x57] = &anl_a_indir_rx;
+    CPU.op[0x50] = &jnc_offset;
+    CPU.op[0x51] = &acall_offset;
+    CPU.op[0x52] = &anl_mem_a;
+    CPU.op[0x53] = &anl_mem_imm;
+    CPU.op[0x54] = &anl_a_imm;
+    CPU.op[0x55] = &anl_a_mem;
+    CPU.op[0x56] = &anl_a_indir_rx;
+    CPU.op[0x57] = &anl_a_indir_rx;
 
-    aCPU->op[0x60] = &jz_offset;
-    aCPU->op[0x61] = &ajmp_offset;
-    aCPU->op[0x62] = &xrl_mem_a;
-    aCPU->op[0x63] = &xrl_mem_imm;
-    aCPU->op[0x64] = &xrl_a_imm;
-    aCPU->op[0x65] = &xrl_a_mem;
-    aCPU->op[0x66] = &xrl_a_indir_rx;
-    aCPU->op[0x67] = &xrl_a_indir_rx;
+    CPU.op[0x60] = &jz_offset;
+    CPU.op[0x61] = &ajmp_offset;
+    CPU.op[0x62] = &xrl_mem_a;
+    CPU.op[0x63] = &xrl_mem_imm;
+    CPU.op[0x64] = &xrl_a_imm;
+    CPU.op[0x65] = &xrl_a_mem;
+    CPU.op[0x66] = &xrl_a_indir_rx;
+    CPU.op[0x67] = &xrl_a_indir_rx;
 
-    aCPU->op[0x70] = &jnz_offset;
-    aCPU->op[0x71] = &acall_offset;
-    aCPU->op[0x72] = &orl_c_bitaddr;
-    aCPU->op[0x73] = &jmp_indir_a_dptr;
-    aCPU->op[0x74] = &mov_a_imm;
-    aCPU->op[0x75] = &mov_mem_imm;
-    aCPU->op[0x76] = &mov_indir_rx_imm;
-    aCPU->op[0x77] = &mov_indir_rx_imm;
+    CPU.op[0x70] = &jnz_offset;
+    CPU.op[0x71] = &acall_offset;
+    CPU.op[0x72] = &orl_c_bitaddr;
+    CPU.op[0x73] = &jmp_indir_a_dptr;
+    CPU.op[0x74] = &mov_a_imm;
+    CPU.op[0x75] = &mov_mem_imm;
+    CPU.op[0x76] = &mov_indir_rx_imm;
+    CPU.op[0x77] = &mov_indir_rx_imm;
 
-    aCPU->op[0x80] = &sjmp_offset;
-    aCPU->op[0x81] = &ajmp_offset;
-    aCPU->op[0x82] = &anl_c_bitaddr;
-    aCPU->op[0x83] = &movc_a_indir_a_pc;
-    aCPU->op[0x84] = &div_ab;
-    aCPU->op[0x85] = &mov_mem_mem;
-    aCPU->op[0x86] = &mov_mem_indir_rx;
-    aCPU->op[0x87] = &mov_mem_indir_rx;
+    CPU.op[0x80] = &sjmp_offset;
+    CPU.op[0x81] = &ajmp_offset;
+    CPU.op[0x82] = &anl_c_bitaddr;
+    CPU.op[0x83] = &movc_a_indir_a_pc;
+    CPU.op[0x84] = &div_ab;
+    CPU.op[0x85] = &mov_mem_mem;
+    CPU.op[0x86] = &mov_mem_indir_rx;
+    CPU.op[0x87] = &mov_mem_indir_rx;
 
-    aCPU->op[0x90] = &mov_dptr_imm;
-    aCPU->op[0x91] = &acall_offset;
-    aCPU->op[0x92] = &mov_bitaddr_c;
-    aCPU->op[0x93] = &movc_a_indir_a_dptr;
-    aCPU->op[0x94] = &subb_a_imm;
-    aCPU->op[0x95] = &subb_a_mem;
-    aCPU->op[0x96] = &subb_a_indir_rx;
-    aCPU->op[0x97] = &subb_a_indir_rx;
+    CPU.op[0x90] = &mov_dptr_imm;
+    CPU.op[0x91] = &acall_offset;
+    CPU.op[0x92] = &mov_bitaddr_c;
+    CPU.op[0x93] = &movc_a_indir_a_dptr;
+    CPU.op[0x94] = &subb_a_imm;
+    CPU.op[0x95] = &subb_a_mem;
+    CPU.op[0x96] = &subb_a_indir_rx;
+    CPU.op[0x97] = &subb_a_indir_rx;
 
-    aCPU->op[0xa0] = &orl_c_compl_bitaddr;
-    aCPU->op[0xa1] = &ajmp_offset;
-    aCPU->op[0xa2] = &mov_c_bitaddr;
-    aCPU->op[0xa3] = &inc_dptr;
-    aCPU->op[0xa4] = &mul_ab;
-    aCPU->op[0xa5] = &nop; // unused
-    aCPU->op[0xa6] = &mov_indir_rx_mem;
-    aCPU->op[0xa7] = &mov_indir_rx_mem;
+    CPU.op[0xa0] = &orl_c_compl_bitaddr;
+    CPU.op[0xa1] = &ajmp_offset;
+    CPU.op[0xa2] = &mov_c_bitaddr;
+    CPU.op[0xa3] = &inc_dptr;
+    CPU.op[0xa4] = &mul_ab;
+    CPU.op[0xa5] = &nop; // unused
+    CPU.op[0xa6] = &mov_indir_rx_mem;
+    CPU.op[0xa7] = &mov_indir_rx_mem;
 
-    aCPU->op[0xb0] = &anl_c_compl_bitaddr;
-    aCPU->op[0xb1] = &acall_offset;
-    aCPU->op[0xb2] = &cpl_bitaddr;
-    aCPU->op[0xb3] = &cpl_c;
-    aCPU->op[0xb4] = &cjne_a_imm_offset;
-    aCPU->op[0xb5] = &cjne_a_mem_offset;
-    aCPU->op[0xb6] = &cjne_indir_rx_imm_offset;
-    aCPU->op[0xb7] = &cjne_indir_rx_imm_offset;
+    CPU.op[0xb0] = &anl_c_compl_bitaddr;
+    CPU.op[0xb1] = &acall_offset;
+    CPU.op[0xb2] = &cpl_bitaddr;
+    CPU.op[0xb3] = &cpl_c;
+    CPU.op[0xb4] = &cjne_a_imm_offset;
+    CPU.op[0xb5] = &cjne_a_mem_offset;
+    CPU.op[0xb6] = &cjne_indir_rx_imm_offset;
+    CPU.op[0xb7] = &cjne_indir_rx_imm_offset;
 
-    aCPU->op[0xc0] = &push_mem;
-    aCPU->op[0xc1] = &ajmp_offset;
-    aCPU->op[0xc2] = &clr_bitaddr;
-    aCPU->op[0xc3] = &clr_c;
-    aCPU->op[0xc4] = &swap_a;
-    aCPU->op[0xc5] = &xch_a_mem;
-    aCPU->op[0xc6] = &xch_a_indir_rx;
-    aCPU->op[0xc7] = &xch_a_indir_rx;
+    CPU.op[0xc0] = &push_mem;
+    CPU.op[0xc1] = &ajmp_offset;
+    CPU.op[0xc2] = &clr_bitaddr;
+    CPU.op[0xc3] = &clr_c;
+    CPU.op[0xc4] = &swap_a;
+    CPU.op[0xc5] = &xch_a_mem;
+    CPU.op[0xc6] = &xch_a_indir_rx;
+    CPU.op[0xc7] = &xch_a_indir_rx;
 
-    aCPU->op[0xd0] = &pop_mem;
-    aCPU->op[0xd1] = &acall_offset;
-    aCPU->op[0xd2] = &setb_bitaddr;
-    aCPU->op[0xd3] = &setb_c;
-    aCPU->op[0xd4] = &da_a;
-    aCPU->op[0xd5] = &djnz_mem_offset;
-    aCPU->op[0xd6] = &xchd_a_indir_rx;
-    aCPU->op[0xd7] = &xchd_a_indir_rx;
+    CPU.op[0xd0] = &pop_mem;
+    CPU.op[0xd1] = &acall_offset;
+    CPU.op[0xd2] = &setb_bitaddr;
+    CPU.op[0xd3] = &setb_c;
+    CPU.op[0xd4] = &da_a;
+    CPU.op[0xd5] = &djnz_mem_offset;
+    CPU.op[0xd6] = &xchd_a_indir_rx;
+    CPU.op[0xd7] = &xchd_a_indir_rx;
 
-    aCPU->op[0xe0] = &movx_a_indir_dptr;
-    aCPU->op[0xe1] = &ajmp_offset;
-    aCPU->op[0xe2] = &movx_a_indir_rx;
-    aCPU->op[0xe3] = &movx_a_indir_rx;
-    aCPU->op[0xe4] = &clr_a;
-    aCPU->op[0xe5] = &mov_a_mem;
-    aCPU->op[0xe6] = &mov_a_indir_rx;
-    aCPU->op[0xe7] = &mov_a_indir_rx;
+    CPU.op[0xe0] = &movx_a_indir_dptr;
+    CPU.op[0xe1] = &ajmp_offset;
+    CPU.op[0xe2] = &movx_a_indir_rx;
+    CPU.op[0xe3] = &movx_a_indir_rx;
+    CPU.op[0xe4] = &clr_a;
+    CPU.op[0xe5] = &mov_a_mem;
+    CPU.op[0xe6] = &mov_a_indir_rx;
+    CPU.op[0xe7] = &mov_a_indir_rx;
 
-    aCPU->op[0xf0] = &movx_indir_dptr_a;
-    aCPU->op[0xf1] = &acall_offset;
-    aCPU->op[0xf2] = &movx_indir_rx_a;
-    aCPU->op[0xf3] = &movx_indir_rx_a;
-    aCPU->op[0xf4] = &cpl_a;
-    aCPU->op[0xf5] = &mov_mem_a;
-    aCPU->op[0xf6] = &mov_indir_rx_a;
-    aCPU->op[0xf7] = &mov_indir_rx_a;
+    CPU.op[0xf0] = &movx_indir_dptr_a;
+    CPU.op[0xf1] = &acall_offset;
+    CPU.op[0xf2] = &movx_indir_rx_a;
+    CPU.op[0xf3] = &movx_indir_rx_a;
+    CPU.op[0xf4] = &cpl_a;
+    CPU.op[0xf5] = &mov_mem_a;
+    CPU.op[0xf6] = &mov_indir_rx_a;
+    CPU.op[0xf7] = &mov_indir_rx_a;
 }
 
-uint8_t do_op(struct em8051 *aCPU)
+uint8_t do_op()
 {
     switch (OPCODE)
     {
-    case 0x00: return nop(aCPU);
-    case 0x01: return ajmp_offset(aCPU);
-    case 0x02: return ljmp_address(aCPU);
-    case 0x03: return rr_a(aCPU);
-    case 0x04: return inc_a(aCPU);
-    case 0x05: return inc_mem(aCPU);
-    case 0x06: return inc_indir_rx(aCPU);
-    case 0x07: return inc_indir_rx(aCPU);
+    case 0x00: return nop();
+    case 0x01: return ajmp_offset();
+    case 0x02: return ljmp_address();
+    case 0x03: return rr_a();
+    case 0x04: return inc_a();
+    case 0x05: return inc_mem();
+    case 0x06: return inc_indir_rx();
+    case 0x07: return inc_indir_rx();
 
     case 0x08:
     case 0x09:
@@ -2135,16 +2135,16 @@ uint8_t do_op(struct em8051 *aCPU)
     case 0x0c:
     case 0x0d:
     case 0x0e:
-    case 0x0f: return inc_rx(aCPU);
+    case 0x0f: return inc_rx();
 
-    case 0x10: return jbc_bitaddr_offset(aCPU);
-    case 0x11: return acall_offset(aCPU);
-    case 0x12: return lcall_address(aCPU);
-    case 0x13: return rrc_a(aCPU);
-    case 0x14: return dec_a(aCPU);
-    case 0x15: return dec_mem(aCPU);
-    case 0x16: return dec_indir_rx(aCPU);
-    case 0x17: return dec_indir_rx(aCPU);
+    case 0x10: return jbc_bitaddr_offset();
+    case 0x11: return acall_offset();
+    case 0x12: return lcall_address();
+    case 0x13: return rrc_a();
+    case 0x14: return dec_a();
+    case 0x15: return dec_mem();
+    case 0x16: return dec_indir_rx();
+    case 0x17: return dec_indir_rx();
 
     case 0x18:
     case 0x19:
@@ -2153,16 +2153,16 @@ uint8_t do_op(struct em8051 *aCPU)
     case 0x1c:
     case 0x1d:
     case 0x1e:
-    case 0x1f: return dec_rx(aCPU);
+    case 0x1f: return dec_rx();
 
-    case 0x20: return jb_bitaddr_offset(aCPU);
-    case 0x21: return ajmp_offset(aCPU);
-    case 0x22: return ret(aCPU);
-    case 0x23: return rl_a(aCPU);
-    case 0x24: return add_a_imm(aCPU);
-    case 0x25: return add_a_mem(aCPU);
-    case 0x26: return add_a_indir_rx(aCPU);
-    case 0x27: return add_a_indir_rx(aCPU);
+    case 0x20: return jb_bitaddr_offset();
+    case 0x21: return ajmp_offset();
+    case 0x22: return ret();
+    case 0x23: return rl_a();
+    case 0x24: return add_a_imm();
+    case 0x25: return add_a_mem();
+    case 0x26: return add_a_indir_rx();
+    case 0x27: return add_a_indir_rx();
 
     case 0x28:
     case 0x29:
@@ -2171,16 +2171,16 @@ uint8_t do_op(struct em8051 *aCPU)
     case 0x2c:
     case 0x2d:
     case 0x2e:
-    case 0x2f: return add_a_rx(aCPU);
+    case 0x2f: return add_a_rx();
 
-    case 0x30: return jnb_bitaddr_offset(aCPU);
-    case 0x31: return acall_offset(aCPU);
-    case 0x32: return reti(aCPU);
-    case 0x33: return rlc_a(aCPU);
-    case 0x34: return addc_a_imm(aCPU);
-    case 0x35: return addc_a_mem(aCPU);
-    case 0x36: return addc_a_indir_rx(aCPU);
-    case 0x37: return addc_a_indir_rx(aCPU);
+    case 0x30: return jnb_bitaddr_offset();
+    case 0x31: return acall_offset();
+    case 0x32: return reti();
+    case 0x33: return rlc_a();
+    case 0x34: return addc_a_imm();
+    case 0x35: return addc_a_mem();
+    case 0x36: return addc_a_indir_rx();
+    case 0x37: return addc_a_indir_rx();
 
     case 0x38:
     case 0x39:
@@ -2189,16 +2189,16 @@ uint8_t do_op(struct em8051 *aCPU)
     case 0x3c:
     case 0x3d:
     case 0x3e:
-    case 0x3f: return addc_a_rx(aCPU);
+    case 0x3f: return addc_a_rx();
 
-    case 0x40: return jc_offset(aCPU);
-    case 0x41: return ajmp_offset(aCPU);
-    case 0x42: return orl_mem_a(aCPU);
-    case 0x43: return orl_mem_imm(aCPU);
-    case 0x44: return orl_a_imm(aCPU);
-    case 0x45: return orl_a_mem(aCPU);
-    case 0x46: return orl_a_indir_rx(aCPU);
-    case 0x47: return orl_a_indir_rx(aCPU);
+    case 0x40: return jc_offset();
+    case 0x41: return ajmp_offset();
+    case 0x42: return orl_mem_a();
+    case 0x43: return orl_mem_imm();
+    case 0x44: return orl_a_imm();
+    case 0x45: return orl_a_mem();
+    case 0x46: return orl_a_indir_rx();
+    case 0x47: return orl_a_indir_rx();
 
     case 0x48:
     case 0x49:
@@ -2207,16 +2207,16 @@ uint8_t do_op(struct em8051 *aCPU)
     case 0x4c:
     case 0x4d:
     case 0x4e:
-    case 0x4f: return orl_a_rx(aCPU);
+    case 0x4f: return orl_a_rx();
 
-    case 0x50: return jnc_offset(aCPU);
-    case 0x51: return acall_offset(aCPU);
-    case 0x52: return anl_mem_a(aCPU);
-    case 0x53: return anl_mem_imm(aCPU);
-    case 0x54: return anl_a_imm(aCPU);
-    case 0x55: return anl_a_mem(aCPU);
-    case 0x56: return anl_a_indir_rx(aCPU);
-    case 0x57: return anl_a_indir_rx(aCPU);
+    case 0x50: return jnc_offset();
+    case 0x51: return acall_offset();
+    case 0x52: return anl_mem_a();
+    case 0x53: return anl_mem_imm();
+    case 0x54: return anl_a_imm();
+    case 0x55: return anl_a_mem();
+    case 0x56: return anl_a_indir_rx();
+    case 0x57: return anl_a_indir_rx();
 
     case 0x58:
     case 0x59:
@@ -2225,16 +2225,16 @@ uint8_t do_op(struct em8051 *aCPU)
     case 0x5c:
     case 0x5d:
     case 0x5e:
-    case 0x5f: return anl_a_rx(aCPU);
+    case 0x5f: return anl_a_rx();
 
-    case 0x60: return jz_offset(aCPU);
-    case 0x61: return ajmp_offset(aCPU);
-    case 0x62: return xrl_mem_a(aCPU);
-    case 0x63: return xrl_mem_imm(aCPU);
-    case 0x64: return xrl_a_imm(aCPU);
-    case 0x65: return xrl_a_mem(aCPU);
-    case 0x66: return xrl_a_indir_rx(aCPU);
-    case 0x67: return xrl_a_indir_rx(aCPU);
+    case 0x60: return jz_offset();
+    case 0x61: return ajmp_offset();
+    case 0x62: return xrl_mem_a();
+    case 0x63: return xrl_mem_imm();
+    case 0x64: return xrl_a_imm();
+    case 0x65: return xrl_a_mem();
+    case 0x66: return xrl_a_indir_rx();
+    case 0x67: return xrl_a_indir_rx();
 
     case 0x68:
     case 0x69:
@@ -2243,16 +2243,16 @@ uint8_t do_op(struct em8051 *aCPU)
     case 0x6c:
     case 0x6d:
     case 0x6e:
-    case 0x6f: return xrl_a_rx(aCPU);
+    case 0x6f: return xrl_a_rx();
 
-    case 0x70: return jnz_offset(aCPU);
-    case 0x71: return acall_offset(aCPU);
-    case 0x72: return orl_c_bitaddr(aCPU);
-    case 0x73: return jmp_indir_a_dptr(aCPU);
-    case 0x74: return mov_a_imm(aCPU);
-    case 0x75: return mov_mem_imm(aCPU);
-    case 0x76: return mov_indir_rx_imm(aCPU);
-    case 0x77: return mov_indir_rx_imm(aCPU);
+    case 0x70: return jnz_offset();
+    case 0x71: return acall_offset();
+    case 0x72: return orl_c_bitaddr();
+    case 0x73: return jmp_indir_a_dptr();
+    case 0x74: return mov_a_imm();
+    case 0x75: return mov_mem_imm();
+    case 0x76: return mov_indir_rx_imm();
+    case 0x77: return mov_indir_rx_imm();
 
     case 0x78:
     case 0x79:
@@ -2261,16 +2261,16 @@ uint8_t do_op(struct em8051 *aCPU)
     case 0x7c:
     case 0x7d:
     case 0x7e:
-    case 0x7f: return mov_rx_imm(aCPU);
+    case 0x7f: return mov_rx_imm();
 
-    case 0x80: return sjmp_offset(aCPU);
-    case 0x81: return ajmp_offset(aCPU);
-    case 0x82: return anl_c_bitaddr(aCPU);
-    case 0x83: return movc_a_indir_a_pc(aCPU);
-    case 0x84: return div_ab(aCPU);
-    case 0x85: return mov_mem_mem(aCPU);
-    case 0x86: return mov_mem_indir_rx(aCPU);
-    case 0x87: return mov_mem_indir_rx(aCPU);
+    case 0x80: return sjmp_offset();
+    case 0x81: return ajmp_offset();
+    case 0x82: return anl_c_bitaddr();
+    case 0x83: return movc_a_indir_a_pc();
+    case 0x84: return div_ab();
+    case 0x85: return mov_mem_mem();
+    case 0x86: return mov_mem_indir_rx();
+    case 0x87: return mov_mem_indir_rx();
 
     case 0x88:
     case 0x89:
@@ -2279,16 +2279,16 @@ uint8_t do_op(struct em8051 *aCPU)
     case 0x8c:
     case 0x8d:
     case 0x8e:
-    case 0x8f: return mov_mem_rx(aCPU);
+    case 0x8f: return mov_mem_rx();
 
-    case 0x90: return mov_dptr_imm(aCPU);
-    case 0x91: return acall_offset(aCPU);
-    case 0x92: return mov_bitaddr_c(aCPU);
-    case 0x93: return movc_a_indir_a_dptr(aCPU);
-    case 0x94: return subb_a_imm(aCPU);
-    case 0x95: return subb_a_mem(aCPU);
-    case 0x96: return subb_a_indir_rx(aCPU);
-    case 0x97: return subb_a_indir_rx(aCPU);
+    case 0x90: return mov_dptr_imm();
+    case 0x91: return acall_offset();
+    case 0x92: return mov_bitaddr_c();
+    case 0x93: return movc_a_indir_a_dptr();
+    case 0x94: return subb_a_imm();
+    case 0x95: return subb_a_mem();
+    case 0x96: return subb_a_indir_rx();
+    case 0x97: return subb_a_indir_rx();
 
     case 0x98:
     case 0x99:
@@ -2297,16 +2297,16 @@ uint8_t do_op(struct em8051 *aCPU)
     case 0x9c:
     case 0x9d:
     case 0x9e:
-    case 0x9f: return subb_a_rx(aCPU);
+    case 0x9f: return subb_a_rx();
 
-    case 0xa0: return orl_c_compl_bitaddr(aCPU);
-    case 0xa1: return ajmp_offset(aCPU);
-    case 0xa2: return mov_c_bitaddr(aCPU);
-    case 0xa3: return inc_dptr(aCPU);
-    case 0xa4: return mul_ab(aCPU);
-    case 0xa5: return nop(aCPU); // unused
-    case 0xa6: return mov_indir_rx_mem(aCPU);
-    case 0xa7: return mov_indir_rx_mem(aCPU);
+    case 0xa0: return orl_c_compl_bitaddr();
+    case 0xa1: return ajmp_offset();
+    case 0xa2: return mov_c_bitaddr();
+    case 0xa3: return inc_dptr();
+    case 0xa4: return mul_ab();
+    case 0xa5: return nop(); // unused
+    case 0xa6: return mov_indir_rx_mem();
+    case 0xa7: return mov_indir_rx_mem();
 
     case 0xa8:
     case 0xa9:
@@ -2315,16 +2315,16 @@ uint8_t do_op(struct em8051 *aCPU)
     case 0xac:
     case 0xad:
     case 0xae:
-    case 0xaf: return mov_rx_mem(aCPU);
+    case 0xaf: return mov_rx_mem();
 
-    case 0xb0: return anl_c_compl_bitaddr(aCPU);
-    case 0xb1: return acall_offset(aCPU);
-    case 0xb2: return cpl_bitaddr(aCPU);
-    case 0xb3: return cpl_c(aCPU);
-    case 0xb4: return cjne_a_imm_offset(aCPU);
-    case 0xb5: return cjne_a_mem_offset(aCPU);
-    case 0xb6: return cjne_indir_rx_imm_offset(aCPU);
-    case 0xb7: return cjne_indir_rx_imm_offset(aCPU);
+    case 0xb0: return anl_c_compl_bitaddr();
+    case 0xb1: return acall_offset();
+    case 0xb2: return cpl_bitaddr();
+    case 0xb3: return cpl_c();
+    case 0xb4: return cjne_a_imm_offset();
+    case 0xb5: return cjne_a_mem_offset();
+    case 0xb6: return cjne_indir_rx_imm_offset();
+    case 0xb7: return cjne_indir_rx_imm_offset();
 
     case 0xb8:
     case 0xb9:
@@ -2333,16 +2333,16 @@ uint8_t do_op(struct em8051 *aCPU)
     case 0xbc:
     case 0xbd:
     case 0xbe:
-    case 0xbf: return cjne_rx_imm_offset(aCPU);
+    case 0xbf: return cjne_rx_imm_offset();
 
-    case 0xc0: return push_mem(aCPU);
-    case 0xc1: return ajmp_offset(aCPU);
-    case 0xc2: return clr_bitaddr(aCPU);
-    case 0xc3: return clr_c(aCPU);
-    case 0xc4: return swap_a(aCPU);
-    case 0xc5: return xch_a_mem(aCPU);
-    case 0xc6: return xch_a_indir_rx(aCPU);
-    case 0xc7: return xch_a_indir_rx(aCPU);
+    case 0xc0: return push_mem();
+    case 0xc1: return ajmp_offset();
+    case 0xc2: return clr_bitaddr();
+    case 0xc3: return clr_c();
+    case 0xc4: return swap_a();
+    case 0xc5: return xch_a_mem();
+    case 0xc6: return xch_a_indir_rx();
+    case 0xc7: return xch_a_indir_rx();
 
     case 0xc8:
     case 0xc9:
@@ -2351,16 +2351,16 @@ uint8_t do_op(struct em8051 *aCPU)
     case 0xcc:
     case 0xcd:
     case 0xce:
-    case 0xcf: return xch_a_rx(aCPU);
+    case 0xcf: return xch_a_rx();
 
-    case 0xd0: return pop_mem(aCPU);
-    case 0xd1: return acall_offset(aCPU);
-    case 0xd2: return setb_bitaddr(aCPU);
-    case 0xd3: return setb_c(aCPU);
-    case 0xd4: return da_a(aCPU);
-    case 0xd5: return djnz_mem_offset(aCPU);
-    case 0xd6: return xchd_a_indir_rx(aCPU);
-    case 0xd7: return xchd_a_indir_rx(aCPU);
+    case 0xd0: return pop_mem();
+    case 0xd1: return acall_offset();
+    case 0xd2: return setb_bitaddr();
+    case 0xd3: return setb_c();
+    case 0xd4: return da_a();
+    case 0xd5: return djnz_mem_offset();
+    case 0xd6: return xchd_a_indir_rx();
+    case 0xd7: return xchd_a_indir_rx();
 
     case 0xd8:
     case 0xd9:
@@ -2369,16 +2369,16 @@ uint8_t do_op(struct em8051 *aCPU)
     case 0xdc:
     case 0xdd:
     case 0xde:
-    case 0xdf: return djnz_rx_offset(aCPU);
+    case 0xdf: return djnz_rx_offset();
 
-    case 0xe0: return movx_a_indir_dptr(aCPU);
-    case 0xe1: return ajmp_offset(aCPU);
-    case 0xe2: return movx_a_indir_rx(aCPU);
-    case 0xe3: return movx_a_indir_rx(aCPU);
-    case 0xe4: return clr_a(aCPU);
-    case 0xe5: return mov_a_mem(aCPU);
-    case 0xe6: return mov_a_indir_rx(aCPU);
-    case 0xe7: return mov_a_indir_rx(aCPU);
+    case 0xe0: return movx_a_indir_dptr();
+    case 0xe1: return ajmp_offset();
+    case 0xe2: return movx_a_indir_rx();
+    case 0xe3: return movx_a_indir_rx();
+    case 0xe4: return clr_a();
+    case 0xe5: return mov_a_mem();
+    case 0xe6: return mov_a_indir_rx();
+    case 0xe7: return mov_a_indir_rx();
 
     case 0xe8:
     case 0xe9:
@@ -2387,16 +2387,16 @@ uint8_t do_op(struct em8051 *aCPU)
     case 0xec:
     case 0xed:
     case 0xee:
-    case 0xef: return mov_a_rx(aCPU);
+    case 0xef: return mov_a_rx();
 
-    case 0xf0: return movx_indir_dptr_a(aCPU);
-    case 0xf1: return acall_offset(aCPU);
-    case 0xf2: return movx_indir_rx_a(aCPU);
-    case 0xf3: return movx_indir_rx_a(aCPU);
-    case 0xf4: return cpl_a(aCPU);
-    case 0xf5: return mov_mem_a(aCPU);
-    case 0xf6: return mov_indir_rx_a(aCPU);
-    case 0xf7: return mov_indir_rx_a(aCPU);
+    case 0xf0: return movx_indir_dptr_a();
+    case 0xf1: return acall_offset();
+    case 0xf2: return movx_indir_rx_a();
+    case 0xf3: return movx_indir_rx_a();
+    case 0xf4: return cpl_a();
+    case 0xf5: return mov_mem_a();
+    case 0xf6: return mov_indir_rx_a();
+    case 0xf7: return mov_indir_rx_a();
 
     case 0xf8:
     case 0xf9:
@@ -2405,7 +2405,7 @@ uint8_t do_op(struct em8051 *aCPU)
     case 0xfc:
     case 0xfd:
     case 0xfe:
-    case 0xff: return mov_rx_a(aCPU);
+    case 0xff: return mov_rx_a();
    }
     return 0;
 }

--- a/options.c
+++ b/options.c
@@ -65,12 +65,12 @@ void wipe_options_view()
 {
 }
 
-void build_options_view(struct em8051 *aCPU)
+void build_options_view()
 {
     erase();
 }
 
-void options_editor_keys(struct em8051 *aCPU, int ch)
+void options_editor_keys(int ch)
 {
     switch (ch)
     {
@@ -137,7 +137,7 @@ void options_editor_keys(struct em8051 *aCPU, int ch)
             if (opt_clock_select > 12)
                 opt_clock_select = 12;
             if (opt_clock_select == 12)
-                opt_clock_hz = emu_readhz(aCPU, "Enter custom clock speed", opt_clock_hz);
+                opt_clock_hz = emu_readhz("Enter custom clock speed", opt_clock_hz);
             else
                 opt_clock_hz = clockspeeds[opt_clock_select];
             if (opt_clock_hz == 0) 
@@ -174,7 +174,7 @@ void options_editor_keys(struct em8051 *aCPU, int ch)
     }
 }
 
-void options_update(struct em8051 *aCPU)
+void options_update()
 {
     int i;
     mvprintw(1, 1, "Options");

--- a/popups.c
+++ b/popups.c
@@ -36,7 +36,7 @@
 // store the object filename (Accessed through command line as well)
 char filename[256];
 
-void emu_popup(struct em8051 *aCPU, char *aTitle, char *aMessage)
+void emu_popup(char *aTitle, char *aMessage)
 {
     WINDOW * exc;
     nocbreak();
@@ -66,10 +66,10 @@ void emu_popup(struct em8051 *aCPU, char *aTitle, char *aMessage)
 
     getch();
     delwin(exc);
-    refreshview(aCPU);
+    refreshview();
 }
 
-void emu_exception(struct em8051 *aCPU, int aCode)
+void emu_exception(int aCode)
 {
     WINDOW * exc;
 
@@ -142,10 +142,10 @@ void emu_exception(struct em8051 *aCPU, int aCode)
 
     getch();
     delwin(exc);
-    change_view(aCPU, MAIN_VIEW);
+    change_view(MAIN_VIEW);
 }
 
-void emu_load(struct em8051 *aCPU)
+void emu_load()
 {
     WINDOW * exc;
     int pos = 0;
@@ -196,31 +196,31 @@ void emu_load(struct em8051 *aCPU)
         }
     }
 
-    result = load_obj(aCPU, filename);
+    result = load_obj(filename);
     delwin(exc);
-    refreshview(aCPU);
+    refreshview();
 
     switch (result)
     {
     case -1:
-        emu_popup(aCPU, "Load error", "File not found.");
+        emu_popup("Load error", "File not found.");
         break;
     case -2:
-        emu_popup(aCPU, "Load error", "Bad file format.");
+        emu_popup("Load error", "Bad file format.");
         break;
     case -3:
-        emu_popup(aCPU, "Load error", "Unsupported HEX file version.");
+        emu_popup("Load error", "Unsupported HEX file version.");
         break;
     case -4:
-        emu_popup(aCPU, "Load error", "Checksum failure.");
+        emu_popup("Load error", "Checksum failure.");
         break;
     case -5:
-        emu_popup(aCPU, "Load error", "No end of data marker found.");
+        emu_popup("Load error", "No end of data marker found.");
         break;
     }
 }
 
-int emu_readvalue(struct em8051 *aCPU, const char *aPrompt, int aOldvalue, int aValueSize)
+int emu_readvalue(const char *aPrompt, int aOldvalue, int aValueSize)
 {
     WINDOW * exc;
     int pos = 0;
@@ -276,7 +276,7 @@ int emu_readvalue(struct em8051 *aCPU, const char *aPrompt, int aOldvalue, int a
         {
             int currvalue = strtol(temp, NULL, 16);
             char assembly[64];
-            decode(aCPU, currvalue, assembly);
+            decode(currvalue, assembly);
             wmove(exc,2,5 + aValueSize);
             waddstr(exc, "                                        ");
             wmove(exc,2,5 + aValueSize);
@@ -310,11 +310,11 @@ int emu_readvalue(struct em8051 *aCPU, const char *aPrompt, int aOldvalue, int a
     while (ch != '\n');
 
     delwin(exc);
-    refreshview(aCPU);
+    refreshview();
     return strtol(temp, NULL, 16);
 }
 
-int emu_readhz(struct em8051 *aCPU, const char *aPrompt, int aOldvalue)
+int emu_readhz(const char *aPrompt, int aOldvalue)
 {
     WINDOW * exc;
     int pos = 0;
@@ -366,11 +366,11 @@ int emu_readhz(struct em8051 *aCPU, const char *aPrompt, int aOldvalue)
     while (ch != '\n');
 
     delwin(exc);
-    refreshview(aCPU);
+    refreshview();
     return strtol(temp, NULL, 10);
 }
 
-int emu_reset(struct em8051 *aCPU)
+int emu_reset()
 {
     WINDOW * exc;
     int ch = 0;
@@ -402,26 +402,26 @@ int emu_reset(struct em8051 *aCPU)
     {
     case 's':
     case 'S':
-        aCPU->mPC = 0;
+        CPU.mPC = 0;
         result = 1;
         break;
     case 'r':
     case 'R':
-        reset(aCPU, 0);
+        reset(0);
         result = 1;
         break;
     case 'w':
     case 'W':
-        reset(aCPU, 1);
+        reset(1);
         result = 1;
         break;
     }
     delwin(exc);
-    refreshview(aCPU);
+    refreshview();
     return result;
 }
 
-void emu_help(struct em8051 *aCPU)
+void emu_help()
 {
     WINDOW * exc;
 
@@ -466,5 +466,5 @@ void emu_help(struct em8051 *aCPU)
     getch();
 
     delwin(exc);
-    refreshview(aCPU);
+    refreshview();
 }


### PR DESCRIPTION
The code can leverage emulating multiple CPUs, but it is cleaner simpler & more performant to only have 1 static CPU instead of forcing all the access be indirect. 

The typical use case being to emulate only 1 CPU, which is reflected by the UI that only supports 1.

Full process isolation per CPU and inter-process communication is a more realistic option anyway.