### PR TITLE
Enhance reset and the opcode dispatch strategy

### DIFF
--- a/core.c
+++ b/core.c
@@ -477,7 +477,11 @@ bool tick(struct em8051 *aCPU)
         if (is_idle) {
             aCPU->mTickDelay = 1;
         } else {
+#ifdef USE_SWITCH_DISPATCH
+            aCPU->mTickDelay = do_op(aCPU);
+#else // USE_SWITCH_DISPATCH
             aCPU->mTickDelay = aCPU->op[aCPU->mCodeMem[aCPU->mPC & (aCPU->mCodeMemMaxIdx)]](aCPU);
+#endif // USE_SWITCH_DISPATCH
         }
         ticked = true;
         // update parity bit
@@ -505,7 +509,11 @@ uint8_t decode(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
         strcpy(aBuffer, "POWER DOWN");
         return 0;
     }
+#ifdef USE_SWITCH_DISPATCH
+    return do_dec(aCPU, aPosition, aBuffer);
+#else // USE_SWITCH_DISPATCH
     return aCPU->dec[aCPU->mCodeMem[aPosition & (aCPU->mCodeMemMaxIdx)]](aCPU, aPosition, aBuffer);
+#endif // USE_SWITCH_DISPATCH
 }
 
 void reset(struct em8051 *aCPU, int aWipe)

--- a/core.c
+++ b/core.c
@@ -508,39 +508,44 @@ uint8_t decode(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
     return aCPU->dec[aCPU->mCodeMem[aPosition & (aCPU->mCodeMemMaxIdx)]](aCPU, aPosition, aBuffer);
 }
 
-void reset(struct em8051 *aCPU, bool aWipe)
+void reset(struct em8051 *aCPU, int aWipe)
 {
-    // clear memory, set registers to bootup values, etc    
-    if (aWipe)
+    // clear memory
+    if (aWipe & RESET_RAM)
     {
-        memset(aCPU->mCodeMem, 0, aCPU->mCodeMemMaxIdx+1);
         memset(aCPU->mExtData, 0, aCPU->mExtDataMaxIdx+1);
         memset(aCPU->mLowerData, 0, 128);
         if (aCPU->mUpperData) 
             memset(aCPU->mUpperData, 0, 128);
     }
 
-    memset(aCPU->mSFR, 0, 128);
+    // Wipe out Code Region
+    if (aWipe & RESET_ROM)
+        memset(aCPU->mCodeMem, 0, aCPU->mCodeMemMaxIdx+1);
 
-    aCPU->mPC = 0;
-    aCPU->mTickDelay = 0;
-    aCPU->mSFR[REG_SP] = 7;
-    aCPU->mSFR[REG_P0] = 0xff;
-    aCPU->mSFR[REG_P1] = 0xff;
-    aCPU->mSFR[REG_P2] = 0xff;
-    aCPU->mSFR[REG_P3] = 0xff;
+    if (aWipe & RESET_SFR)
+    {
+        // set registers to bootup values, etc
+        memset(aCPU->mSFR, 0, 128);
+
+        aCPU->mPC = 0;
+        aCPU->mTickDelay = 0;
+        aCPU->mSFR[REG_SP] = 7;
+        aCPU->mSFR[REG_P0] = 0xff;
+        aCPU->mSFR[REG_P1] = 0xff;
+        aCPU->mSFR[REG_P2] = 0xff;
+        aCPU->mSFR[REG_P3] = 0xff;
+        aCPU->mSFR[REG_PCON] = 0x00;
+
+        // Random values
+        aCPU->mSFR[REG_SBUF] = rand();
+    }
 
     // Power-off flag will be 1 only after a power on (cold reset).
     // A warm reset doesn’t affect the value of this bit
     // ... Therefore, we only set it if aWipe is 1
-    if (aWipe)
+    if (aWipe & RESET_RAM)
         aCPU->mSFR[REG_PCON] |= (1<<4);
-
-    // Random values
-    if (aWipe)
-        aCPU->mSFR[REG_SBUF] = rand();
-
-    // build function pointer lists
 
     // Clean internal variables
     aCPU->mInterruptActive = 0;

--- a/core.c
+++ b/core.c
@@ -508,9 +508,6 @@ uint8_t decode(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
     return aCPU->dec[aCPU->mCodeMem[aPosition & (aCPU->mCodeMemMaxIdx)]](aCPU, aPosition, aBuffer);
 }
 
-void disasm_setptrs(struct em8051 *aCPU);
-void op_setptrs(struct em8051 *aCPU);
-
 void reset(struct em8051 *aCPU, bool aWipe)
 {
     // clear memory, set registers to bootup values, etc    
@@ -544,9 +541,6 @@ void reset(struct em8051 *aCPU, bool aWipe)
         aCPU->mSFR[REG_SBUF] = rand();
 
     // build function pointer lists
-
-    disasm_setptrs(aCPU);
-    op_setptrs(aCPU);
 
     // Clean internal variables
     aCPU->mInterruptActive = 0;

--- a/disasm.c
+++ b/disasm.c
@@ -1090,6 +1090,8 @@ static uint8_t disasm_mov_rx_a(struct em8051 *aCPU, uint16_t aPosition, char *aB
     return 1;
 }
 
+#ifndef USE_SWITCH_DISPATCH
+
 void disasm_setptrs(struct em8051 *aCPU)
 {
     int i;
@@ -1256,3 +1258,302 @@ void disasm_setptrs(struct em8051 *aCPU)
     aCPU->dec[0xf6] = &disasm_mov_indir_rx_a;
     aCPU->dec[0xf7] = &disasm_mov_indir_rx_a;
 }
+
+#else // USE_SWITCH_DISPATCH
+
+uint8_t do_dec(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer)
+{
+    switch (OPCODE)
+    {
+        case 0x00: return disasm_nop(aCPU, aPosition, aBuffer);
+        case 0x01: return disasm_ajmp_offset(aCPU, aPosition, aBuffer);
+        case 0x02: return disasm_ljmp_address(aCPU, aPosition, aBuffer);
+        case 0x03: return disasm_rr_a(aCPU, aPosition, aBuffer);
+        case 0x04: return disasm_inc_a(aCPU, aPosition, aBuffer);
+        case 0x05: return disasm_inc_mem(aCPU, aPosition, aBuffer);
+        case 0x06: return disasm_inc_indir_rx(aCPU, aPosition, aBuffer);
+        case 0x07: return disasm_inc_indir_rx(aCPU, aPosition, aBuffer);
+
+        case 0x08:
+        case 0x09:
+        case 0x0a:
+        case 0x0b:
+        case 0x0c:
+        case 0x0d:
+        case 0x0e:
+        case 0x0f: return disasm_inc_rx(aCPU, aPosition, aBuffer);
+
+        case 0x10: return disasm_jbc_bitaddr_offset(aCPU, aPosition, aBuffer);
+        case 0x11: return disasm_acall_offset(aCPU, aPosition, aBuffer);
+        case 0x12: return disasm_lcall_address(aCPU, aPosition, aBuffer);
+        case 0x13: return disasm_rrc_a(aCPU, aPosition, aBuffer);
+        case 0x14: return disasm_dec_a(aCPU, aPosition, aBuffer);
+        case 0x15: return disasm_dec_mem(aCPU, aPosition, aBuffer);
+        case 0x16: return disasm_dec_indir_rx(aCPU, aPosition, aBuffer);
+        case 0x17: return disasm_dec_indir_rx(aCPU, aPosition, aBuffer);
+
+        case 0x18:
+        case 0x19:
+        case 0x1a:
+        case 0x1b:
+        case 0x1c:
+        case 0x1d:
+        case 0x1e:
+        case 0x1f: return disasm_dec_rx(aCPU, aPosition, aBuffer);
+
+        case 0x20: return disasm_jb_bitaddr_offset(aCPU, aPosition, aBuffer);
+        case 0x21: return disasm_ajmp_offset(aCPU, aPosition, aBuffer);
+        case 0x22: return disasm_ret(aCPU, aPosition, aBuffer);
+        case 0x23: return disasm_rl_a(aCPU, aPosition, aBuffer);
+        case 0x24: return disasm_add_a_imm(aCPU, aPosition, aBuffer);
+        case 0x25: return disasm_add_a_mem(aCPU, aPosition, aBuffer);
+        case 0x26: return disasm_add_a_indir_rx(aCPU, aPosition, aBuffer);
+        case 0x27: return disasm_add_a_indir_rx(aCPU, aPosition, aBuffer);
+
+        case 0x28:
+        case 0x29:
+        case 0x2a:
+        case 0x2b:
+        case 0x2c:
+        case 0x2d:
+        case 0x2e:
+        case 0x2f: return disasm_add_a_rx(aCPU, aPosition, aBuffer);
+
+        case 0x30: return disasm_jnb_bitaddr_offset(aCPU, aPosition, aBuffer);
+        case 0x31: return disasm_acall_offset(aCPU, aPosition, aBuffer);
+        case 0x32: return disasm_reti(aCPU, aPosition, aBuffer);
+        case 0x33: return disasm_rlc_a(aCPU, aPosition, aBuffer);
+        case 0x34: return disasm_addc_a_imm(aCPU, aPosition, aBuffer);
+        case 0x35: return disasm_addc_a_mem(aCPU, aPosition, aBuffer);
+        case 0x36: return disasm_addc_a_indir_rx(aCPU, aPosition, aBuffer);
+        case 0x37: return disasm_addc_a_indir_rx(aCPU, aPosition, aBuffer);
+
+        case 0x38:
+        case 0x39:
+        case 0x3a:
+        case 0x3b:
+        case 0x3c:
+        case 0x3d:
+        case 0x3e:
+        case 0x3f: return disasm_addc_a_rx(aCPU, aPosition, aBuffer);
+
+        case 0x40: return disasm_jc_offset(aCPU, aPosition, aBuffer);
+        case 0x41: return disasm_ajmp_offset(aCPU, aPosition, aBuffer);
+        case 0x42: return disasm_orl_mem_a(aCPU, aPosition, aBuffer);
+        case 0x43: return disasm_orl_mem_imm(aCPU, aPosition, aBuffer);
+        case 0x44: return disasm_orl_a_imm(aCPU, aPosition, aBuffer);
+        case 0x45: return disasm_orl_a_mem(aCPU, aPosition, aBuffer);
+        case 0x46: return disasm_orl_a_indir_rx(aCPU, aPosition, aBuffer);
+        case 0x47: return disasm_orl_a_indir_rx(aCPU, aPosition, aBuffer);
+
+        case 0x48:
+        case 0x49:
+        case 0x4a:
+        case 0x4b:
+        case 0x4c:
+        case 0x4d:
+        case 0x4e:
+        case 0x4f: return disasm_orl_a_rx(aCPU, aPosition, aBuffer);
+
+        case 0x50: return disasm_jnc_offset(aCPU, aPosition, aBuffer);
+        case 0x51: return disasm_acall_offset(aCPU, aPosition, aBuffer);
+        case 0x52: return disasm_anl_mem_a(aCPU, aPosition, aBuffer);
+        case 0x53: return disasm_anl_mem_imm(aCPU, aPosition, aBuffer);
+        case 0x54: return disasm_anl_a_imm(aCPU, aPosition, aBuffer);
+        case 0x55: return disasm_anl_a_mem(aCPU, aPosition, aBuffer);
+        case 0x56: return disasm_anl_a_indir_rx(aCPU, aPosition, aBuffer);
+        case 0x57: return disasm_anl_a_indir_rx(aCPU, aPosition, aBuffer);
+
+        case 0x58:
+        case 0x59:
+        case 0x5a:
+        case 0x5b:
+        case 0x5c:
+        case 0x5d:
+        case 0x5e:
+        case 0x5f: return disasm_anl_a_rx(aCPU, aPosition, aBuffer);
+
+        case 0x60: return disasm_jz_offset(aCPU, aPosition, aBuffer);
+        case 0x61: return disasm_ajmp_offset(aCPU, aPosition, aBuffer);
+        case 0x62: return disasm_xrl_mem_a(aCPU, aPosition, aBuffer);
+        case 0x63: return disasm_xrl_mem_imm(aCPU, aPosition, aBuffer);
+        case 0x64: return disasm_xrl_a_imm(aCPU, aPosition, aBuffer);
+        case 0x65: return disasm_xrl_a_mem(aCPU, aPosition, aBuffer);
+        case 0x66: return disasm_xrl_a_indir_rx(aCPU, aPosition, aBuffer);
+        case 0x67: return disasm_xrl_a_indir_rx(aCPU, aPosition, aBuffer);
+
+        case 0x68:
+        case 0x69:
+        case 0x6a:
+        case 0x6b:
+        case 0x6c:
+        case 0x6d:
+        case 0x6e:
+        case 0x6f: return disasm_xrl_a_rx(aCPU, aPosition, aBuffer);
+
+        case 0x70: return disasm_jnz_offset(aCPU, aPosition, aBuffer);
+        case 0x71: return disasm_acall_offset(aCPU, aPosition, aBuffer);
+        case 0x72: return disasm_orl_c_bitaddr(aCPU, aPosition, aBuffer);
+        case 0x73: return disasm_jmp_indir_a_dptr(aCPU, aPosition, aBuffer);
+        case 0x74: return disasm_mov_a_imm(aCPU, aPosition, aBuffer);
+        case 0x75: return disasm_mov_mem_imm(aCPU, aPosition, aBuffer);
+        case 0x76: return disasm_mov_indir_rx_imm(aCPU, aPosition, aBuffer);
+        case 0x77: return disasm_mov_indir_rx_imm(aCPU, aPosition, aBuffer);
+
+        case 0x78:
+        case 0x79:
+        case 0x7a:
+        case 0x7b:
+        case 0x7c:
+        case 0x7d:
+        case 0x7e:
+        case 0x7f: return disasm_mov_rx_imm(aCPU, aPosition, aBuffer);
+
+        case 0x80: return disasm_sjmp_offset(aCPU, aPosition, aBuffer);
+        case 0x81: return disasm_ajmp_offset(aCPU, aPosition, aBuffer);
+        case 0x82: return disasm_anl_c_bitaddr(aCPU, aPosition, aBuffer);
+        case 0x83: return disasm_movc_a_indir_a_pc(aCPU, aPosition, aBuffer);
+        case 0x84: return disasm_div_ab(aCPU, aPosition, aBuffer);
+        case 0x85: return disasm_mov_mem_mem(aCPU, aPosition, aBuffer);
+        case 0x86: return disasm_mov_mem_indir_rx(aCPU, aPosition, aBuffer);
+        case 0x87: return disasm_mov_mem_indir_rx(aCPU, aPosition, aBuffer);
+
+        case 0x88:
+        case 0x89:
+        case 0x8a:
+        case 0x8b:
+        case 0x8c:
+        case 0x8d:
+        case 0x8e:
+        case 0x8f: return disasm_mov_mem_rx(aCPU, aPosition, aBuffer);
+
+        case 0x90: return disasm_mov_dptr_imm(aCPU, aPosition, aBuffer);
+        case 0x91: return disasm_acall_offset(aCPU, aPosition, aBuffer);
+        case 0x92: return disasm_mov_bitaddr_c(aCPU, aPosition, aBuffer);
+        case 0x93: return disasm_movc_a_indir_a_dptr(aCPU, aPosition, aBuffer);
+        case 0x94: return disasm_subb_a_imm(aCPU, aPosition, aBuffer);
+        case 0x95: return disasm_subb_a_mem(aCPU, aPosition, aBuffer);
+        case 0x96: return disasm_subb_a_indir_rx(aCPU, aPosition, aBuffer);
+        case 0x97: return disasm_subb_a_indir_rx(aCPU, aPosition, aBuffer);
+
+        case 0x98:
+        case 0x99:
+        case 0x9a:
+        case 0x9b:
+        case 0x9c:
+        case 0x9d:
+        case 0x9e:
+        case 0x9f: return disasm_subb_a_rx(aCPU, aPosition, aBuffer);
+
+        case 0xa0: return disasm_orl_c_compl_bitaddr(aCPU, aPosition, aBuffer);
+        case 0xa1: return disasm_ajmp_offset(aCPU, aPosition, aBuffer);
+        case 0xa2: return disasm_mov_c_bitaddr(aCPU, aPosition, aBuffer);
+        case 0xa3: return disasm_inc_dptr(aCPU, aPosition, aBuffer);
+        case 0xa4: return disasm_mul_ab(aCPU, aPosition, aBuffer);
+        case 0xa5: return disasm_nop(aCPU, aPosition, aBuffer); // unused
+        case 0xa6: return disasm_mov_indir_rx_mem(aCPU, aPosition, aBuffer);
+        case 0xa7: return disasm_mov_indir_rx_mem(aCPU, aPosition, aBuffer);
+
+        case 0xa8:
+        case 0xa9:
+        case 0xaa:
+        case 0xab:
+        case 0xac:
+        case 0xad:
+        case 0xae:
+        case 0xaf: return disasm_mov_rx_mem(aCPU, aPosition, aBuffer);
+
+        case 0xb0: return disasm_anl_c_compl_bitaddr(aCPU, aPosition, aBuffer);
+        case 0xb1: return disasm_acall_offset(aCPU, aPosition, aBuffer);
+        case 0xb2: return disasm_cpl_bitaddr(aCPU, aPosition, aBuffer);
+        case 0xb3: return disasm_cpl_c(aCPU, aPosition, aBuffer);
+        case 0xb4: return disasm_cjne_a_imm_offset(aCPU, aPosition, aBuffer);
+        case 0xb5: return disasm_cjne_a_mem_offset(aCPU, aPosition, aBuffer);
+        case 0xb6: return disasm_cjne_indir_rx_imm_offset(aCPU, aPosition, aBuffer);
+        case 0xb7: return disasm_cjne_indir_rx_imm_offset(aCPU, aPosition, aBuffer);
+
+        case 0xb8:
+        case 0xb9:
+        case 0xba:
+        case 0xbb:
+        case 0xbc:
+        case 0xbd:
+        case 0xbe:
+        case 0xbf: return disasm_cjne_rx_imm_offset(aCPU, aPosition, aBuffer);
+
+        case 0xc0: return disasm_push_mem(aCPU, aPosition, aBuffer);
+        case 0xc1: return disasm_ajmp_offset(aCPU, aPosition, aBuffer);
+        case 0xc2: return disasm_clr_bitaddr(aCPU, aPosition, aBuffer);
+        case 0xc3: return disasm_clr_c(aCPU, aPosition, aBuffer);
+        case 0xc4: return disasm_swap_a(aCPU, aPosition, aBuffer);
+        case 0xc5: return disasm_xch_a_mem(aCPU, aPosition, aBuffer);
+        case 0xc6: return disasm_xch_a_indir_rx(aCPU, aPosition, aBuffer);
+        case 0xc7: return disasm_xch_a_indir_rx(aCPU, aPosition, aBuffer);
+
+        case 0xc8:
+        case 0xc9:
+        case 0xca:
+        case 0xcb:
+        case 0xcc:
+        case 0xcd:
+        case 0xce:
+        case 0xcf: return disasm_xch_a_rx(aCPU, aPosition, aBuffer);
+
+        case 0xd0: return disasm_pop_mem(aCPU, aPosition, aBuffer);
+        case 0xd1: return disasm_acall_offset(aCPU, aPosition, aBuffer);
+        case 0xd2: return disasm_setb_bitaddr(aCPU, aPosition, aBuffer);
+        case 0xd3: return disasm_setb_c(aCPU, aPosition, aBuffer);
+        case 0xd4: return disasm_da_a(aCPU, aPosition, aBuffer);
+        case 0xd5: return disasm_djnz_mem_offset(aCPU, aPosition, aBuffer);
+        case 0xd6: return disasm_xchd_a_indir_rx(aCPU, aPosition, aBuffer);
+        case 0xd7: return disasm_xchd_a_indir_rx(aCPU, aPosition, aBuffer);
+
+        case 0xd8:
+        case 0xd9:
+        case 0xda:
+        case 0xdb:
+        case 0xdc:
+        case 0xdd:
+        case 0xde:
+        case 0xdf: return disasm_djnz_rx_offset(aCPU, aPosition, aBuffer);
+
+        case 0xe0: return disasm_movx_a_indir_dptr(aCPU, aPosition, aBuffer);
+        case 0xe1: return disasm_ajmp_offset(aCPU, aPosition, aBuffer);
+        case 0xe2: return disasm_movx_a_indir_rx(aCPU, aPosition, aBuffer);
+        case 0xe3: return disasm_movx_a_indir_rx(aCPU, aPosition, aBuffer);
+        case 0xe4: return disasm_clr_a(aCPU, aPosition, aBuffer);
+        case 0xe5: return disasm_mov_a_mem(aCPU, aPosition, aBuffer);
+        case 0xe6: return disasm_mov_a_indir_rx(aCPU, aPosition, aBuffer);
+        case 0xe7: return disasm_mov_a_indir_rx(aCPU, aPosition, aBuffer);
+
+        case 0xe8:
+        case 0xe9:
+        case 0xea:
+        case 0xeb:
+        case 0xec:
+        case 0xed:
+        case 0xee:
+        case 0xef: return disasm_mov_a_rx(aCPU, aPosition, aBuffer);
+
+        case 0xf0: return disasm_movx_indir_dptr_a(aCPU, aPosition, aBuffer);
+        case 0xf1: return disasm_acall_offset(aCPU, aPosition, aBuffer);
+        case 0xf2: return disasm_movx_indir_rx_a(aCPU, aPosition, aBuffer);
+        case 0xf3: return disasm_movx_indir_rx_a(aCPU, aPosition, aBuffer);
+        case 0xf4: return disasm_cpl_a(aCPU, aPosition, aBuffer);
+        case 0xf5: return disasm_mov_mem_a(aCPU, aPosition, aBuffer);
+        case 0xf6: return disasm_mov_indir_rx_a(aCPU, aPosition, aBuffer);
+        case 0xf7: return disasm_mov_indir_rx_a(aCPU, aPosition, aBuffer);
+
+        case 0xf8:
+        case 0xf9:
+        case 0xfa:
+        case 0xfb:
+        case 0xfc:
+        case 0xfd:
+        case 0xfe:
+        case 0xff: return disasm_mov_rx_a(aCPU, aPosition, aBuffer);
+    }
+
+    return 0;
+}
+#endif // USE_SWITCH_DISPATCH

--- a/emu.c
+++ b/emu.c
@@ -302,7 +302,7 @@ int main(int parc, char ** pars)
     disasm_setptrs(&emu);
     op_setptrs(&emu);
 
-    reset(&emu, 1);
+    reset(&emu, RESET_RAM | RESET_SFR | RESET_ROM);
 
     if (parc > 1)
     {
@@ -547,11 +547,11 @@ int main(int parc, char ** pars)
             break;
         case 'z':
 	    // Equivalent of "R)eset (init regs, set PC to zero)"
-	    reset(&emu, 0);
+	    reset(&emu, RESET_SFR);
 	    break;
         case 'Z':
-	    // Equivalent of "W)ipe (init regs, set PC to zero, clear memory)"
-	    reset(&emu, 1);
+	    // Equivalent of "P)ower-cycle (init regs, set PC to zero, clear memory)"
+	    reset(&emu, RESET_RAM | RESET_SFR);
 	    break;
         case KEY_END:
             clocks = 0;

--- a/emu.c
+++ b/emu.c
@@ -272,6 +272,9 @@ void change_view(struct em8051 *aCPU, int changeto)
     }
 }
 
+void disasm_setptrs(struct em8051 *aCPU);
+void op_setptrs(struct em8051 *aCPU);
+
 int main(int parc, char ** pars)
 {
     int ch = 0;
@@ -295,6 +298,9 @@ int main(int parc, char ** pars)
     emu.sfrread[REG_P1] = emu_sfrread;
     emu.sfrread[REG_P2] = emu_sfrread;
     emu.sfrread[REG_P3] = emu_sfrread;
+
+    disasm_setptrs(&emu);
+    op_setptrs(&emu);
 
     reset(&emu, 1);
 

--- a/emu.c
+++ b/emu.c
@@ -272,8 +272,11 @@ void change_view(struct em8051 *aCPU, int changeto)
     }
 }
 
+#if USE_SWITCH_DISPATCH
+#else // USE_SWITCH_DISPATCH
 void disasm_setptrs(struct em8051 *aCPU);
 void op_setptrs(struct em8051 *aCPU);
+#endif // USE_SWITCH_DISPATCH
 
 int main(int parc, char ** pars)
 {
@@ -299,8 +302,11 @@ int main(int parc, char ** pars)
     emu.sfrread[REG_P2] = emu_sfrread;
     emu.sfrread[REG_P3] = emu_sfrread;
 
+#ifdef USE_SWITCH_DISPATCH
+#else // USE_SWITCH_DISPATCH
     disasm_setptrs(&emu);
     op_setptrs(&emu);
+#endif // USE_SWITCH_DISPATCH
 
     reset(&emu, RESET_RAM | RESET_SFR | RESET_ROM);
 

--- a/emu8051.h
+++ b/emu8051.h
@@ -106,6 +106,7 @@ bool tick(struct em8051 *aCPU);
 // buffer must be big enough (64 bytes is very safe). 
 // Returns length of opcode.
 uint8_t decode(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer);
+uint8_t do_dec(struct em8051 *aCPU, uint16_t aPosition, char *aBuffer);
 
 // Load an intel hex format object file. Returns negative for errors.
 int load_obj(struct em8051 *aCPU, char *aFilename);

--- a/emu8051.h
+++ b/emu8051.h
@@ -96,7 +96,7 @@ struct em8051
 // set the emulator into reset state. Must be called before tick(), as
 // it also initializes the function pointers. aWipe tells whether to reset
 // all memory to zero.
-void reset(struct em8051 *aCPU, bool aWipe);
+void reset(struct em8051 *aCPU, int aWipe);
 
 // run one emulator tick, or 12 hardware clock cycles.
 // returns "true" if a new operation was executed.
@@ -260,3 +260,10 @@ enum EM8051_EXCEPTION
     EXCEPTION_ILLEGAL_OPCODE     // for the single 'reserved' opcode in the architecture
 };
 
+enum EM8051_RESET
+{
+    RESET_NONE  = 0x00,  // No RESET
+    RESET_SFR   = 0x01,  // Wipe SFR
+    RESET_RAM   = 0x02,  // Wipe RAM
+    RESET_ROM   = 0x04,  // Wipe CODE
+};

--- a/opcodes.c
+++ b/opcodes.c
@@ -1636,6 +1636,7 @@ static uint8_t mov_rx_a(struct em8051 *aCPU)
     return 0;
 }
 
+#ifndef USE_SWITCH_DISPATCH
 void op_setptrs(struct em8051 *aCPU)
 {
     uint8_t i;
@@ -1802,6 +1803,8 @@ void op_setptrs(struct em8051 *aCPU)
     aCPU->op[0xf6] = &mov_indir_rx_a;
     aCPU->op[0xf7] = &mov_indir_rx_a;
 }
+
+#else // USE_SWITCH_DISPATCH
 
 uint8_t do_op(struct em8051 *aCPU)
 {
@@ -2097,4 +2100,5 @@ uint8_t do_op(struct em8051 *aCPU)
    }
     return 0;
 }
+#endif // USE_SWITCH_DISPATCH
 

--- a/popups.c
+++ b/popups.c
@@ -391,8 +391,10 @@ int emu_reset(struct em8051 *aCPU)
     wmove(exc, 3, 2);
     waddstr(exc, "R)eset (init regs, set PC to zero)");
     wmove(exc, 4, 2);
-    waddstr(exc, "W)ipe (init regs, set PC to zero, clear memory)");
+    waddstr(exc, "P)ower-cycle (init regs, set PC to zero, clear memory)");
     wmove(exc, 6, 2);
+    waddstr(exc, "W)ipe (fully erase the chip, *including* ROM)");
+    wmove(exc, 8, 2);
     waddstr(exc, "z/Z from main screen are shortcuts to HOME+R or HOME+W");
     wrefresh(exc);
 
@@ -407,12 +409,17 @@ int emu_reset(struct em8051 *aCPU)
         break;
     case 'r':
     case 'R':
-        reset(aCPU, 0);
+        reset(aCPU, RESET_SFR);
+        result = 1;
+        break;
+    case 'p':
+    case 'P':
+        reset(aCPU, RESET_SFR | RESET_RAM);
         result = 1;
         break;
     case 'w':
     case 'W':
-        reset(aCPU, 1);
+        reset(aCPU, RESET_SFR | RESET_RAM | RESET_ROM);
         result = 1;
         break;
     }


### PR DESCRIPTION
This is to cleanup the function table versus switch for opcode dispatch. 

There is no need for unused functions to be compiled.

It also contains some RESET enhancements. As soft reset, hard reset and power-cycle isn't the same. So we can emulate powered down IDLE scenarios. 