### PR TITLE
Save ACC low nibble before altered, fix XCHD behaviour.

### DIFF
--- a/opcodes.c
+++ b/opcodes.c
@@ -1335,8 +1335,9 @@ static uint8_t xchd_a_indir_rx(struct em8051 *aCPU)
 {
     uint8_t address = INDIR_RX_ADDRESS;
     uint8_t value = read_mem_indir(aCPU, address);
+    uint8_t nibble = ACC & 0x0f;
     ACC = (ACC & 0xf0) | (value & 0x0f);
-    value = (value & 0xf0) | (ACC & 0x0f);
+    value = (value & 0xf0) | nibble;
     write_mem_indir(aCPU, address, value);
     PC++;
     return 0;


### PR DESCRIPTION
Take below codes as example:

```
  mov R0, #0x20h
  mov A, #0xffh
  mov @R0, #0x11h
  xchd A, @R0
```

After `xchd`, Accumlator should be 0xf1 and RAM 0x20h should be 0x1f. 

but RAM 0x20h now is '0x11', since low 4 bit of ACC was altered by 'value' before use it to alter the 'value'. 
