### PR TITLE
Fix mainview.c warning on gcc compilation

### DIFF
--- a/mainview.c
+++ b/mainview.c
@@ -593,7 +593,7 @@ void mainview_update(struct em8051 *aCPU)
 
 
     werase(miscview);
-    wprintw(miscview, "\nCycles :% 10u\n", clocks);
+    wprintw(miscview, "\nCycles : %10u\n", clocks);
     wprintw(miscview, "Time   :% 14.3fms\n", 1000.0f * clocks * (1.0f/opt_clock_hz));
     wprintw(miscview, "HW     : Super8051 @%0.1fMHz\n", opt_clock_hz / (1000*1000.0f));
 


### PR DESCRIPTION
Space after printf % character does make sense only when the value can be negative. If it is always positive, the space can be before the number in all cases. GCC warns about this, this change fixes it.

This fixes following warning:
mainview.c:596:38: warning: ' ' flag used with ‘%u’ gnu_printf format [-Wformat=]
  596 |     wprintw(miscview, "\nCycles :% 10u\n", clocks);