### PR TITLE
Fix stack memory access

### DIFF
--- a/opcodes.c
+++ b/opcodes.c
@@ -111,7 +111,7 @@ static void write_mem_indir(struct em8051 *aCPU, uint8_t aAddress, uint8_t value
 void push_to_stack(struct em8051 *aCPU, uint8_t aValue)
 {
     aCPU->mSFR[REG_SP]++;
-    write_mem(aCPU, aCPU->mSFR[REG_SP], aValue);
+    write_mem_indir(aCPU, aCPU->mSFR[REG_SP], aValue);
     if (aCPU->mSFR[REG_SP] == 0)
         if (aCPU->except)
             aCPU->except(aCPU, EXCEPTION_STACK);
@@ -119,7 +119,7 @@ void push_to_stack(struct em8051 *aCPU, uint8_t aValue)
 
 static uint8_t pop_from_stack(struct em8051 *aCPU)
 {
-    uint8_t value = read_mem(aCPU, aCPU->mSFR[REG_SP]);
+    uint8_t value = read_mem_indir(aCPU, aCPU->mSFR[REG_SP]);
     aCPU->mSFR[REG_SP]--;
 
     if (aCPU->mSFR[REG_SP] == 0xff)


### PR DESCRIPTION
According to the 8051 documentation, all stack operations use indirect memory access (which makes sense, you don't want to be getting your stack and SFRs mixed up).

The way I found this: I am emulating an image that uses the high 128bits of memory for the stack, and I had no idea how it ended up in a routine that was supposed to be disabled, turns out the return address in the stack was corrupted, so on a ret, it jumped to somewhere in the middle of the disabled routine.

Without this change, you can expect memory, register and stack corruption whenever the stack pointer is above 0x7f.