### PR TITLE
Fix bug in opcode 0x87 (MOV @Ri, direct)

### DIFF
--- a/opcodes.c
+++ b/opcodes.c
@@ -440,8 +440,8 @@ static uint8_t reti(struct em8051 *aCPU)
             if (aCPU->int_a[hi] != aCPU->mSFR[REG_ACC])
                 aCPU->except(aCPU, EXCEPTION_IRET_ACC_MISMATCH);
             if (aCPU->int_sp[hi] != aCPU->mSFR[REG_SP])
-                aCPU->except(aCPU, EXCEPTION_IRET_SP_MISMATCH);    
-            if ((aCPU->int_psw[hi] & (PSWMASK_OV | PSWMASK_RS0 | PSWMASK_RS1 | PSWMASK_AC | PSWMASK_C)) !=                 
+                aCPU->except(aCPU, EXCEPTION_IRET_SP_MISMATCH);
+            if ((aCPU->int_psw[hi] & (PSWMASK_OV | PSWMASK_RS0 | PSWMASK_RS1 | PSWMASK_AC | PSWMASK_C)) !=
                 (aCPU->mSFR[REG_PSW] & (PSWMASK_OV | PSWMASK_RS0 | PSWMASK_RS1 | PSWMASK_AC | PSWMASK_C)))
                 aCPU->except(aCPU, EXCEPTION_IRET_PSW_MISMATCH);
         }
@@ -844,8 +844,9 @@ static uint8_t mov_mem_indir_rx(struct em8051 *aCPU)
 {
     uint8_t address_from = OPERAND1;
     uint8_t address_to = INDIR_RX_ADDRESS;
-    uint8_t value = read_mem_indir(aCPU, address_from);
-    write_mem(aCPU, address_to, value);
+    // FIX: Use read_mem() for direct source, write_mem_indir() for indirect dest
+    uint8_t value = read_mem(aCPU, address_from);
+    write_mem_indir(aCPU, address_to, value);
     PC += 2;
     return 1;
 }


### PR DESCRIPTION
I was studying a simulation of real firmware created to a Siemens 80, likely a SAB80C517 (similar to a 8052 in features) and there was a stackoverflow, I used claude code to help debug and found this, I am not sure if this is 100% right, but it seems to fixed the problem, so I am creating this pull request.

Follows the claude description to the problem:
The mov_mem_indir_rx function was using wrong memory access functions:
- Used read_mem_indir() for DIRECT source operand (should be read_mem())
- Used write_mem() for INDIRECT destination operand (should be write_mem_indir())

This caused stack corruption when Ri pointed to Upper RAM (0x80-0xFF) and direct was an SFR address (0x80-0xFF), because write_mem(0x81, val) would write to mSFR[0x01] (SP register) instead of mUpperData[0x01].

Impact: Bosch MA1.7 firmware crashed every ~12k instructions due to SP corruption.
After fix: Firmware runs indefinitely without crashes.

Bug discovered while emulating SAB 80C517 firmware that uses MOV @R1, B where R1=0x81 (Upper RAM) and B=0xF0 (SFR).