### PR TITLE
Fix opcodes 0x86/0x87, source and destination where swapped

### DIFF
--- a/opcodes.c
+++ b/opcodes.c
@@ -842,8 +842,8 @@ static uint8_t mov_mem_mem(struct em8051 *aCPU)
 
 static uint8_t mov_mem_indir_rx(struct em8051 *aCPU)
 {
-    uint8_t address_from = OPERAND1;
-    uint8_t address_to = INDIR_RX_ADDRESS;
+    uint8_t address_from = INDIR_RX_ADDRESS;
+    uint8_t address_to = OPERAND1;
     uint8_t value = read_mem_indir(aCPU, address_from);
     write_mem(aCPU, address_to, value);
     PC += 2;


### PR DESCRIPTION
I saw there is also another PR about this, but the fix for the opcode there is wrong. This is actually the correct fix. My sdcc compiled firmware didn't work, destroying the stack whenever I did something more complex (printf, floating point math). With this fix it works.

My fix is the correct one because this is for instructions like "mov dph,@r0", so the from address is the indirect one, and the destination address is the one from the operand1.

Sorry for needing to redo the PR, the other one accidentally had another unrelated commit on it.